### PR TITLE
15 confession page

### DIFF
--- a/backend/server/src/controllers/confession/confessionCommentController.js
+++ b/backend/server/src/controllers/confession/confessionCommentController.js
@@ -103,8 +103,12 @@ const updateComment = async (req, res) => {
     }
 
     await commentModel.updateComment(commentId, req.user.userId, req.body);
+    const updatedComment = await commentModel.getCommentById(
+      commentId,
+      req.user.userId,
+    );
 
-    res.json({ message: "Comment updated" });
+    res.json({ message: "Comment updated", comment: updatedComment });
   } catch (error) {
     if (error.message === "not found") {
       return res.status(404).json({ message: "comment not found" });
@@ -127,9 +131,12 @@ const deleteComment = async (req, res) => {
       return res.status(404).json({ message: "Comment not found" });
     }
 
-    await commentModel.deleteComment(req.user.userId, commentId);
+    const result = await commentModel.deleteComment(req.user.userId, commentId);
 
-    res.json({ message: "Comment deleted" });
+    res.json({
+      message: "Comment deleted",
+      removedCount: result?.removedCount,
+    });
   } catch (error) {
     if (error.message === "not found") {
       return res.status(404).json({ message: "comment not found" });

--- a/backend/server/src/models/confession/confessionCommentModel.js
+++ b/backend/server/src/models/confession/confessionCommentModel.js
@@ -336,9 +336,24 @@ const getCommentById = async (id, currentUserId = null) => {
     likedByCurrentUser = !!like;
   }
 
+  const author = await db.collection("profiles").findOne(
+    {
+      userId: comment.userId,
+      deletedAt: null,
+    },
+    {
+      projection: {
+        displayName: 1,
+        profilePicture: 1,
+      },
+    },
+  );
+
   return {
     ...comment,
     likedByCurrentUser,
+    authorDisplayName: author?.displayName || null,
+    authorProfilePicture: author?.profilePicture || "",
   };
 };
 
@@ -381,6 +396,7 @@ const deleteComment = async (userId, id) => {
   const session = client.startSession();
 
   const commentId = new ObjectId(id);
+  let removedCount = 0;
 
   try {
     await session.withTransaction(async () => {
@@ -439,6 +455,7 @@ const deleteComment = async (userId, id) => {
       );
 
       const totalDeleted = 1 + replyIds.length;
+      removedCount = totalDeleted;
 
       await confessionsCollection.updateOne(
         { _id: comment.confessionId },
@@ -447,7 +464,7 @@ const deleteComment = async (userId, id) => {
       );
     });
 
-    return { success: true };
+    return { success: true, removedCount };
   } catch (error) {
     console.error("Transaction failed:", error);
     throw error;

--- a/backend/server/src/models/confession/confessionCommentModel.js
+++ b/backend/server/src/models/confession/confessionCommentModel.js
@@ -157,7 +157,7 @@ const getCommentsByConfession = async (
             },
           },
           {
-            $project: { displayName: 1 },
+            $project: { displayName: 1, profilePicture: 1 },
           },
         ],
         as: "author",
@@ -198,6 +198,7 @@ const getCommentsByConfession = async (
     likedByCurrentUser: likedCommentIds.has(comment._id.toString()),
     replyCount: comment.replyCount || 0,
     authorDisplayName: comment.author?.displayName || null,
+    authorProfilePicture: comment.author?.profilePicture || "",
   }));
 
   let nextCursor = null;
@@ -264,7 +265,7 @@ const getRepliesByComment = async (
             },
           },
           {
-            $project: { displayName: 1 },
+            $project: { displayName: 1, profilePicture: 1 },
           },
         ],
         as: "author",
@@ -302,6 +303,7 @@ const getRepliesByComment = async (
     ...reply,
     likedByCurrentUser: likedReplyIds.has(reply._id.toString()),
     authorDisplayName: reply.author?.displayName || null,
+    authorProfilePicture: reply.author?.profilePicture || "",
   }));
 
   let nextCursor = null;

--- a/backend/server/src/models/confession/confessionModel.js
+++ b/backend/server/src/models/confession/confessionModel.js
@@ -12,6 +12,7 @@ const PROTECTED_FIELDS = [
   "views",
   "likesCount",
   "commentCount",
+  "isEdited",
   "createdAt",
   "deletedAt",
 ];
@@ -91,6 +92,7 @@ const createConfession = async (confessionData) => {
     tags: confessionData.tags || [],
     isAnonymous: confessionData.isAnonymous !== false,
     visibility: confessionData.visibility || "public",
+    isEdited: false,
     views: 0,
     likesCount: 0,
     commentCount: 0,
@@ -378,6 +380,7 @@ const updateConfession = async (id, userId, updateData) => {
     {
       $set: {
         ...updateData,
+        isEdited: true,
         updatedAt: new Date(),
       },
     },

--- a/backend/server/src/models/confession/confessionModel.js
+++ b/backend/server/src/models/confession/confessionModel.js
@@ -63,6 +63,24 @@ const resolveAuthorDisplayName = (confession, currentUserId = null) => {
   return "Anonymous";
 };
 
+const resolveAuthorProfilePicture = (confession, currentUserId = null) => {
+  const profilePicture = confession.author?.profilePicture || "";
+
+  if (!confession.isAnonymous) {
+    return profilePicture;
+  }
+
+  if (
+    currentUserId &&
+    ObjectId.isValid(currentUserId) &&
+    confession.authorId.toString() === currentUserId.toString()
+  ) {
+    return profilePicture;
+  }
+
+  return "";
+};
+
 const createConfession = async (confessionData) => {
   const collection = await getCollection();
   const wordCount = confessionData.content.trim().split(/\s+/).length;
@@ -140,7 +158,7 @@ const getPublishedConfessions = async (cursor, limit, currentUserId, tag) => {
             },
           },
           {
-            $project: { displayName: 1 },
+            $project: { displayName: 1, profilePicture: 1 },
           },
         ],
         as: "author",
@@ -218,6 +236,10 @@ const getPublishedConfessions = async (cursor, limit, currentUserId, tag) => {
       confession.authorId.toString(),
     ),
     authorDisplayName: resolveAuthorDisplayName(confession, currentUserId),
+    authorProfilePicture: resolveAuthorProfilePicture(
+      confession,
+      currentUserId,
+    ),
   }));
 
   let nextCursor = null;
@@ -266,7 +288,7 @@ const getConfessionById = async (id, currentUserId = null) => {
             },
           },
           {
-            $project: { displayName: 1 },
+            $project: { displayName: 1, profilePicture: 1 },
           },
         ],
         as: "author",

--- a/backend/server/src/models/confession/confessionModel.js
+++ b/backend/server/src/models/confession/confessionModel.js
@@ -641,7 +641,7 @@ const getDeletedUserConfessions = async (userId, cursor, limit) => {
             },
           },
           {
-            $project: { displayName: 1 },
+            $project: { displayName: 1, profilePicture: 1 },
           },
         ],
         as: "author",
@@ -664,6 +664,7 @@ const getDeletedUserConfessions = async (userId, cursor, limit) => {
     ...confession,
     followedByCurrentUser: false,
     authorDisplayName: resolveAuthorDisplayName(confession, userId),
+    authorProfilePicture: resolveAuthorProfilePicture(confession, userId),
   }));
 
   let nextCursor = null;

--- a/backend/server/src/models/confession/confessionModel.js
+++ b/backend/server/src/models/confession/confessionModel.js
@@ -352,6 +352,10 @@ const getConfessionById = async (id, currentUserId = null) => {
     followedByCurrentUser,
     savedByCurrentUser,
     authorDisplayName: resolveAuthorDisplayName(confession, currentUserId),
+    authorProfilePicture: resolveAuthorProfilePicture(
+      confession,
+      currentUserId,
+    ),
   };
 };
 
@@ -551,7 +555,7 @@ const getUserConfessions = async (userId, cursor, limit) => {
             },
           },
           {
-            $project: { displayName: 1 },
+            $project: { displayName: 1, profilePicture: 1 },
           },
         ],
         as: "author",
@@ -574,6 +578,7 @@ const getUserConfessions = async (userId, cursor, limit) => {
     ...confession,
     followedByCurrentUser: false,
     authorDisplayName: resolveAuthorDisplayName(confession, userId),
+    authorProfilePicture: resolveAuthorProfilePicture(confession, userId),
   }));
 
   let nextCursor = null;

--- a/backend/server/src/models/confession/confessionModel.js
+++ b/backend/server/src/models/confession/confessionModel.js
@@ -361,9 +361,10 @@ const getConfessionById = async (id, currentUserId = null) => {
 
 const updateConfession = async (id, userId, updateData) => {
   const collection = await getCollection();
+  const confessionObjectId = new ObjectId(id);
 
   const confession = await collection.findOne({
-    _id: new ObjectId(id),
+    _id: confessionObjectId,
     deletedAt: null,
   });
 
@@ -376,15 +377,54 @@ const updateConfession = async (id, userId, updateData) => {
   PROTECTED_FIELDS.forEach((field) => delete updateData[field]);
 
   if (Object.keys(updateData).length === 0) {
-    return { matchedCount: 1, modifiedCount: 0 };
+    return {
+      acknowledged: true,
+      matchedCount: 1,
+      modifiedCount: 0,
+      upsertedCount: 0,
+      upsertedId: null,
+    };
   }
 
-  if (updateData.content) {
+  const fieldsToCompare = ["content", "tags", "isAnonymous", "visibility"];
+  const hasChanges = fieldsToCompare.some((field) => {
+    if (!Object.hasOwn(updateData, field)) {
+      return false;
+    }
+
+    if (field === "tags") {
+      const nextTags = Array.isArray(updateData.tags) ? updateData.tags : [];
+      const currentTags = Array.isArray(confession.tags) ? confession.tags : [];
+
+      if (nextTags.length !== currentTags.length) {
+        return true;
+      }
+
+      return nextTags.some((tag, index) => tag !== currentTags[index]);
+    }
+
+    return updateData[field] !== confession[field];
+  });
+
+  if (!hasChanges) {
+    return {
+      acknowledged: true,
+      matchedCount: 1,
+      modifiedCount: 0,
+      upsertedCount: 0,
+      upsertedId: null,
+    };
+  }
+
+  if (
+    Object.hasOwn(updateData, "content") &&
+    updateData.content !== confession.content
+  ) {
     updateData.wordCount = updateData.content.trim().split(/\s+/).length;
   }
 
   return collection.updateOne(
-    { _id: new ObjectId(id) },
+    { _id: confessionObjectId },
     {
       $set: {
         ...updateData,

--- a/backend/server/src/models/confession/confessionModel.js
+++ b/backend/server/src/models/confession/confessionModel.js
@@ -375,6 +375,10 @@ const updateConfession = async (id, userId, updateData) => {
 
   PROTECTED_FIELDS.forEach((field) => delete updateData[field]);
 
+  if (Object.keys(updateData).length === 0) {
+    return { matchedCount: 1, modifiedCount: 0 };
+  }
+
   if (updateData.content) {
     updateData.wordCount = updateData.content.trim().split(/\s+/).length;
   }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,7 +11,6 @@
         "@tailwindcss/vite": "^4.1.18",
         "@uploadthing/react": "^6.6.0",
         "lucide-react": "latest",
-        "prop-types": "^15.8.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "latest",
@@ -3276,17 +3275,6 @@
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"
-      }
-    },
-    "node_modules/prop-types": {
-      "version": "15.8.1",
-      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
-      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
-      "license": "MIT",
-      "dependencies": {
-        "loose-envify": "^1.4.0",
-        "object-assign": "^4.1.1",
-        "react-is": "^16.13.1"
       }
     },
     "node_modules/punycode": {

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -11,6 +11,7 @@
         "@tailwindcss/vite": "^4.1.18",
         "@uploadthing/react": "^6.6.0",
         "lucide-react": "latest",
+        "prop-types": "^15.8.1",
         "react": "^19.2.0",
         "react-dom": "^19.2.0",
         "react-router-dom": "latest",
@@ -330,6 +331,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -346,6 +348,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -362,6 +365,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -378,6 +382,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -394,6 +399,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -410,6 +416,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -426,6 +433,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -442,6 +450,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -458,6 +467,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -474,6 +484,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -490,6 +501,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -506,6 +518,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -522,6 +535,7 @@
       "cpu": [
         "mips64el"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -538,6 +552,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -554,6 +569,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -570,6 +586,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -586,6 +603,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -602,6 +620,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -618,6 +637,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -634,6 +654,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -650,6 +671,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -666,6 +688,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -682,6 +705,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -698,6 +722,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -714,6 +739,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -730,6 +756,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1007,6 +1034,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1020,6 +1048,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1033,6 +1062,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1046,6 +1076,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1059,6 +1090,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1072,6 +1104,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1085,6 +1118,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1098,6 +1132,7 @@
       "cpu": [
         "arm"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1111,6 +1146,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1124,6 +1160,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1137,6 +1174,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1150,6 +1188,7 @@
       "cpu": [
         "loong64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1163,6 +1202,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1176,6 +1216,7 @@
       "cpu": [
         "ppc64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1189,6 +1230,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1202,6 +1244,7 @@
       "cpu": [
         "riscv64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1215,6 +1258,7 @@
       "cpu": [
         "s390x"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1228,6 +1272,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1241,6 +1286,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1254,6 +1300,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1267,6 +1314,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1280,6 +1328,7 @@
       "cpu": [
         "arm64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1293,6 +1342,7 @@
       "cpu": [
         "ia32"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1306,6 +1356,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1319,6 +1370,7 @@
       "cpu": [
         "x64"
       ],
+      "dev": true,
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1637,6 +1689,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@types/json-schema": {
@@ -2074,6 +2127,7 @@
       "version": "0.27.3",
       "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
       "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "bin": {
@@ -2365,6 +2419,7 @@
       "version": "6.5.0",
       "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
       "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12.0.0"
@@ -2445,6 +2500,7 @@
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
       "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,
@@ -2604,7 +2660,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -2963,6 +3018,18 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3015,6 +3082,7 @@
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
       "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -3042,6 +3110,15 @@
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/optionator": {
       "version": "0.9.4",
@@ -3130,12 +3207,14 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
       "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=12"
@@ -3148,6 +3227,7 @@
       "version": "8.5.6",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.6.tgz",
       "integrity": "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==",
+      "dev": true,
       "funding": [
         {
           "type": "opencollective",
@@ -3198,6 +3278,17 @@
         "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
     "node_modules/punycode": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
@@ -3244,6 +3335,12 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3307,6 +3404,7 @@
       "version": "4.60.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.1.tgz",
       "integrity": "sha512-VmtB2rFU/GroZ4oL8+ZqXgSA38O6GR8KSIvWmEFv63pQ0G6KaBH9s07PO8XTXP4vI+3UJUEypOfjkGfmSBBR0w==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@types/estree": "1.0.8"
@@ -3466,6 +3564,7 @@
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
       "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
@@ -3584,6 +3683,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
       "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,7 +14,6 @@
     "@tailwindcss/vite": "^4.1.18",
     "@uploadthing/react": "^6.6.0",
     "lucide-react": "latest",
-    "prop-types": "^15.8.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "latest",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,7 @@
     "@tailwindcss/vite": "^4.1.18",
     "@uploadthing/react": "^6.6.0",
     "lucide-react": "latest",
+    "prop-types": "^15.8.1",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
     "react-router-dom": "latest",

--- a/frontend/src/pages/Confession.jsx
+++ b/frontend/src/pages/Confession.jsx
@@ -230,6 +230,9 @@ export default function Confession() {
   const pendingBookmarkIdsRef = useRef(new Set());
   const toastTimeoutRef = useRef(null);
   const toastExitTimeoutRef = useRef(null);
+  const pressedLikeTimerRef = useRef(null);
+  const pressedBookmarkTimerRef = useRef(null);
+  const gestureLikeBurstTimerRef = useRef(null);
   const [isToastVisible, setIsToastVisible] = useState(false);
   const commentDialogTitleId = "confession-comments-dialog-title";
   const editDialogTitleId = "confession-edit-dialog-title";
@@ -561,10 +564,15 @@ export default function Confession() {
       });
 
       setPressedLikeId(confessionId);
-      setTimeout(() => {
+      if (pressedLikeTimerRef.current) {
+        clearTimeout(pressedLikeTimerRef.current);
+      }
+
+      pressedLikeTimerRef.current = setTimeout(() => {
         setPressedLikeId((currentId) =>
           currentId === confessionId ? null : currentId,
         );
+        pressedLikeTimerRef.current = null;
       }, 150);
 
       try {
@@ -631,10 +639,15 @@ export default function Confession() {
     });
 
     setPressedBookmarkId(confessionId);
-    setTimeout(() => {
+    if (pressedBookmarkTimerRef.current) {
+      clearTimeout(pressedBookmarkTimerRef.current);
+    }
+
+    pressedBookmarkTimerRef.current = setTimeout(() => {
       setPressedBookmarkId((currentId) =>
         currentId === confessionId ? null : currentId,
       );
+      pressedBookmarkTimerRef.current = null;
     }, 150);
 
     try {
@@ -773,10 +786,15 @@ export default function Confession() {
       }
 
       setGestureLikeBurstId(confessionId);
-      setTimeout(() => {
+      if (gestureLikeBurstTimerRef.current) {
+        clearTimeout(gestureLikeBurstTimerRef.current);
+      }
+
+      gestureLikeBurstTimerRef.current = setTimeout(() => {
         setGestureLikeBurstId((currentId) =>
           currentId === confessionId ? null : currentId,
         );
+        gestureLikeBurstTimerRef.current = null;
       }, 450);
 
       handleToggleLike(confessionId);
@@ -865,6 +883,18 @@ export default function Confession() {
 
       if (toastExitTimeoutRef.current) {
         clearTimeout(toastExitTimeoutRef.current);
+      }
+
+      if (pressedLikeTimerRef.current) {
+        clearTimeout(pressedLikeTimerRef.current);
+      }
+
+      if (pressedBookmarkTimerRef.current) {
+        clearTimeout(pressedBookmarkTimerRef.current);
+      }
+
+      if (gestureLikeBurstTimerRef.current) {
+        clearTimeout(gestureLikeBurstTimerRef.current);
       }
     },
     [],

--- a/frontend/src/pages/Confession.jsx
+++ b/frontend/src/pages/Confession.jsx
@@ -26,6 +26,175 @@ import { useConfessionComments } from "./confession/useConfessionComments";
 import ConfessionFeedCard from "./confession/ConfessionFeedCard";
 import ConfessionModalCommentItem from "./confession/ConfessionModalCommentItem";
 
+const FOCUSABLE_SELECTOR = [
+  "a[href]",
+  "button:not([disabled])",
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+const PREFERRED_FOCUS_SELECTOR = [
+  "textarea:not([disabled])",
+  "input:not([disabled])",
+  "select:not([disabled])",
+  "button:not([disabled])",
+  "a[href]",
+  '[tabindex]:not([tabindex="-1"])',
+].join(", ");
+
+const getFocusableElements = (container) => {
+  if (!(container instanceof HTMLElement)) {
+    return [];
+  }
+
+  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter(
+    (element) =>
+      element instanceof HTMLElement &&
+      !element.hasAttribute("disabled") &&
+      element.getAttribute("aria-hidden") !== "true",
+  );
+};
+
+const moveFocusIntoDialog = (container) => {
+  const preferredFocusableElement =
+    container instanceof HTMLElement
+      ? container.querySelector(PREFERRED_FOCUS_SELECTOR)
+      : null;
+
+  if (preferredFocusableElement instanceof HTMLElement) {
+    preferredFocusableElement.focus();
+    return;
+  }
+
+  if (container instanceof HTMLElement) {
+    container.focus();
+  }
+};
+
+function ModalDialog({
+  isOpen,
+  onClose,
+  title,
+  titleId,
+  closeLabel,
+  widthClassName = "max-w-xl",
+  children,
+}) {
+  const dialogRef = React.useRef(null);
+  const previousFocusRef = React.useRef(null);
+  const onCloseRef = React.useRef(onClose);
+
+  React.useEffect(() => {
+    onCloseRef.current = onClose;
+  }, [onClose]);
+
+  React.useEffect(() => {
+    if (!isOpen) {
+      return undefined;
+    }
+
+    previousFocusRef.current =
+      document.activeElement instanceof HTMLElement
+        ? document.activeElement
+        : null;
+
+    requestAnimationFrame(() => {
+      moveFocusIntoDialog(dialogRef.current);
+    });
+
+    const handleKeyDown = (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        onCloseRef.current();
+        return;
+      }
+
+      if (event.key !== "Tab") {
+        return;
+      }
+
+      const focusableElements = getFocusableElements(dialogRef.current);
+
+      if (focusableElements.length === 0) {
+        event.preventDefault();
+        dialogRef.current?.focus();
+        return;
+      }
+
+      const firstFocusableElement = focusableElements[0];
+      const lastFocusableElement =
+        focusableElements[focusableElements.length - 1];
+      const activeElement = document.activeElement;
+
+      if (event.shiftKey && activeElement === firstFocusableElement) {
+        event.preventDefault();
+        lastFocusableElement.focus();
+        return;
+      }
+
+      if (!event.shiftKey && activeElement === lastFocusableElement) {
+        event.preventDefault();
+        firstFocusableElement.focus();
+      }
+    };
+
+    document.addEventListener("keydown", handleKeyDown);
+
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+
+      if (previousFocusRef.current instanceof HTMLElement) {
+        previousFocusRef.current.focus();
+      }
+    };
+  }, [isOpen]);
+
+  if (!isOpen) {
+    return null;
+  }
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
+      <button
+        type="button"
+        aria-label={closeLabel}
+        onClick={onClose}
+        className="absolute inset-0 bg-slate-900/40 backdrop-blur-[2px]"
+      />
+
+      <div
+        ref={dialogRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={titleId}
+        tabIndex={-1}
+        className={`relative z-10 w-full ${widthClassName} rounded-2xl border border-slate-200 bg-white shadow-xl overflow-hidden`}
+      >
+        <div className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
+          <h4
+            id={titleId}
+            className="text-sm sm:text-base font-semibold text-slate-900 truncate pr-4"
+          >
+            {title}
+          </h4>
+          <button
+            type="button"
+            onClick={onClose}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-900 transition-colors cursor-pointer"
+            aria-label={closeLabel}
+          >
+            <X size={18} />
+          </button>
+        </div>
+
+        {children}
+      </div>
+    </div>
+  );
+}
+
 export default function Confession() {
   // NOSONAR
   const TOAST_DURATION_MS = 3200;
@@ -38,10 +207,13 @@ export default function Confession() {
   const [hasMoreFeed, setHasMoreFeed] = useState(false);
   const [isLoadingFeed, setIsLoadingFeed] = useState(true);
   const [isLoadingMoreFeed, setIsLoadingMoreFeed] = useState(false);
+  const [feedError, setFeedError] = useState("");
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [toast, setToast] = useState(null);
   const [pressedLikeId, setPressedLikeId] = useState(null);
   const [pressedBookmarkId, setPressedBookmarkId] = useState(null);
+  const [pendingLikeIds, setPendingLikeIds] = useState(() => new Set());
+  const [pendingBookmarkIds, setPendingBookmarkIds] = useState(() => new Set());
   const [gestureLikeBurstId, setGestureLikeBurstId] = useState(null);
   const [editingConfessionId, setEditingConfessionId] = useState("");
   const [editConfessionContent, setEditConfessionContent] = useState("");
@@ -54,9 +226,14 @@ export default function Confession() {
   const [deleteTargetConfessionId, setDeleteTargetConfessionId] = useState("");
   const sentinelRef = useRef(null);
   const lastTapRef = useRef({ confessionId: "", time: 0 });
+  const pendingLikeIdsRef = useRef(new Set());
+  const pendingBookmarkIdsRef = useRef(new Set());
   const toastTimeoutRef = useRef(null);
   const toastExitTimeoutRef = useRef(null);
   const [isToastVisible, setIsToastVisible] = useState(false);
+  const commentDialogTitleId = "confession-comments-dialog-title";
+  const editDialogTitleId = "confession-edit-dialog-title";
+  const deleteDialogTitleId = "confession-delete-dialog-title";
 
   const hideToast = React.useCallback(() => {
     setIsToastVisible(false);
@@ -157,8 +334,8 @@ export default function Confession() {
     isDeletingComment,
     isLoadingModalComments,
     modalCommentsError,
-    closeCommentModal,
-    openCommentModal,
+    closeCommentModal: closeCommentModalState,
+    openCommentModal: openCommentModalState,
     handleAddComment,
     handleToggleCommentMenu,
     handleStartEditComment,
@@ -167,6 +344,17 @@ export default function Confession() {
     handleDeleteComment,
     handleConfirmDeleteComment,
   } = useConfessionComments({ setConfessionFeed });
+
+  const closeCommentModal = React.useCallback(() => {
+    closeCommentModalState();
+  }, [closeCommentModalState]);
+
+  const openCommentModal = React.useCallback(
+    async (...args) => {
+      await openCommentModalState(...args);
+    },
+    [openCommentModalState],
+  );
 
   const loadConfessions = React.useCallback(
     async ({ cursor = "", append = false } = {}) => {
@@ -199,10 +387,12 @@ export default function Confession() {
 
         const data = Array.isArray(payload?.data) ? payload.data : [];
 
+        setFeedError("");
         setConfessionFeed((prev) => (append ? [...prev, ...data] : data));
         setNextCursor(payload?.nextCursor || "");
         setHasMoreFeed(Boolean(payload?.hasMore));
       } catch (error) {
+        setFeedError(error.message || "Failed to load confessions.");
         showError(error.message || "Failed to load confessions.");
       } finally {
         setIsLoadingFeed(false);
@@ -324,11 +514,25 @@ export default function Confession() {
 
   const handleToggleLike = React.useCallback(
     async (confessionId) => {
+      if (
+        pendingLikeIdsRef.current.has(confessionId) ||
+        pendingLikeIds.has(confessionId)
+      ) {
+        return;
+      }
+
       const token = localStorage.getItem("token");
       if (!token) {
         showError("Please log in to like confessions.");
         return;
       }
+
+      pendingLikeIdsRef.current.add(confessionId);
+      setPendingLikeIds((prev) => {
+        const next = new Set(prev);
+        next.add(confessionId);
+        return next;
+      });
 
       setPressedLikeId(confessionId);
       setTimeout(() => {
@@ -367,17 +571,38 @@ export default function Confession() {
         );
       } catch (error) {
         showError(error.message || "Failed to toggle like.");
+      } finally {
+        pendingLikeIdsRef.current.delete(confessionId);
+        setPendingLikeIds((prev) => {
+          const next = new Set(prev);
+          next.delete(confessionId);
+          return next;
+        });
       }
     },
-    [showError],
+    [pendingLikeIds, showError],
   );
 
   const handleToggleBookmark = async (confessionId) => {
+    if (
+      pendingBookmarkIdsRef.current.has(confessionId) ||
+      pendingBookmarkIds.has(confessionId)
+    ) {
+      return;
+    }
+
     const token = localStorage.getItem("token");
     if (!token) {
       showError("Please log in to bookmark confessions.");
       return;
     }
+
+    pendingBookmarkIdsRef.current.add(confessionId);
+    setPendingBookmarkIds((prev) => {
+      const next = new Set(prev);
+      next.add(confessionId);
+      return next;
+    });
 
     setPressedBookmarkId(confessionId);
     setTimeout(() => {
@@ -415,6 +640,13 @@ export default function Confession() {
       );
     } catch (error) {
       showError(error.message || "Failed to toggle bookmark.");
+    } finally {
+      pendingBookmarkIdsRef.current.delete(confessionId);
+      setPendingBookmarkIds((prev) => {
+        const next = new Set(prev);
+        next.delete(confessionId);
+        return next;
+      });
     }
   };
 
@@ -661,6 +893,21 @@ export default function Confession() {
         Loading confessions...
       </div>
     );
+  } else if (feedError) {
+    feedContent = (
+      <div className="bg-white rounded-2xl sm:rounded-3xl p-5 sm:p-6 border border-rose-200 shadow-sm">
+        <div className="text-sm text-rose-700">{feedError}</div>
+        <button
+          type="button"
+          onClick={() => {
+            loadConfessions().catch(() => {});
+          }}
+          className="mt-4 inline-flex items-center rounded-full border border-rose-300 px-4 py-2 text-sm font-medium text-rose-700 transition hover:bg-rose-50"
+        >
+          Retry
+        </button>
+      </div>
+    );
   } else if (confessionFeed.length === 0) {
     feedContent = (
       <div className="bg-white rounded-2xl sm:rounded-3xl p-5 sm:p-6 border border-slate-200 shadow-sm text-sm text-slate-500">
@@ -775,235 +1022,186 @@ export default function Confession() {
           </div>
         </main>
 
-        {isCommentModalOpen && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
-            <button
-              type="button"
-              aria-label="Close comments modal"
-              onClick={closeCommentModal}
-              className="absolute inset-0 bg-slate-900/40"
-            />
+        <ModalDialog
+          isOpen={isCommentModalOpen}
+          onClose={closeCommentModal}
+          title={`Comments - ${commentModalTitle}`}
+          titleId={commentDialogTitleId}
+          closeLabel="Close comments modal"
+          widthClassName="max-w-xl"
+        >
+          <div className="max-h-[65vh] overflow-y-auto px-4 py-4 space-y-3">
+            {isLoadingModalComments && (
+              <p className="text-sm text-slate-500">Loading comments...</p>
+            )}
 
-            <div className="relative z-10 w-full max-w-xl rounded-2xl border border-slate-200 bg-white shadow-xl overflow-hidden">
-              <div className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
-                <h4 className="text-sm sm:text-base font-semibold text-slate-900 truncate pr-4">
-                  Comments - {commentModalTitle}
-                </h4>
-                <button
-                  type="button"
-                  onClick={closeCommentModal}
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-900 transition-colors cursor-pointer"
-                  aria-label="Close comments"
-                >
-                  <X size={18} />
-                </button>
-              </div>
+            {!isLoadingModalComments && modalCommentsError && (
+              <p className="text-sm text-rose-600">{modalCommentsError}</p>
+            )}
 
-              <div className="max-h-[65vh] overflow-y-auto px-4 py-4 space-y-3">
-                {isLoadingModalComments && (
-                  <p className="text-sm text-slate-500">Loading comments...</p>
-                )}
+            {!isLoadingModalComments &&
+              !modalCommentsError &&
+              modalComments.length === 0 && (
+                <p className="text-sm text-slate-500">No comments yet.</p>
+              )}
 
-                {!isLoadingModalComments && modalCommentsError && (
-                  <p className="text-sm text-rose-600">{modalCommentsError}</p>
-                )}
-
-                {!isLoadingModalComments &&
-                  !modalCommentsError &&
-                  modalComments.length === 0 && (
-                    <p className="text-sm text-slate-500">No comments yet.</p>
-                  )}
-
-                {!isLoadingModalComments &&
-                  !modalCommentsError &&
-                  modalComments.map((comment) => {
-                    return (
-                      <ConfessionModalCommentItem
-                        key={String(comment?._id || comment?.id || "comment")}
-                        comment={comment}
-                        currentUserId={currentUserId}
-                        activeCommentMenuId={activeCommentMenuId}
-                        editingCommentId={editingCommentId}
-                        editCommentContent={editCommentContent}
-                        isSavingEditedComment={isSavingEditedComment}
-                        deleteTargetCommentId={deleteTargetCommentId}
-                        isDeletingComment={isDeletingComment}
-                        onToggleMenu={handleToggleCommentMenu}
-                        onStartEdit={handleStartEditComment}
-                        onDelete={handleDeleteComment}
-                        onCancelEdit={handleCancelEditComment}
-                        onEditContentChange={setEditCommentContent}
-                        onSaveEdit={handleSaveEditedComment}
-                        onCancelDelete={() => setDeleteTargetCommentId("")}
-                        onConfirmDelete={handleConfirmDeleteComment}
-                      />
-                    );
-                  })}
-              </div>
-
-              <div className="border-t border-slate-100 px-4 py-3">
-                <div className="flex items-end gap-2">
-                  <textarea
-                    value={newCommentContent}
-                    onChange={(event) =>
-                      setNewCommentContent(event.target.value)
-                    }
-                    className="flex-1 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800 outline-none focus:border-rose-300 resize-none"
-                    rows={2}
-                    placeholder="Write a comment..."
+            {!isLoadingModalComments &&
+              !modalCommentsError &&
+              modalComments.map((comment) => {
+                return (
+                  <ConfessionModalCommentItem
+                    key={String(comment?._id || comment?.id || "comment")}
+                    comment={comment}
+                    currentUserId={currentUserId}
+                    activeCommentMenuId={activeCommentMenuId}
+                    editingCommentId={editingCommentId}
+                    editCommentContent={editCommentContent}
+                    isSavingEditedComment={isSavingEditedComment}
+                    deleteTargetCommentId={deleteTargetCommentId}
+                    isDeletingComment={isDeletingComment}
+                    onToggleMenu={handleToggleCommentMenu}
+                    onStartEdit={handleStartEditComment}
+                    onDelete={handleDeleteComment}
+                    onCancelEdit={handleCancelEditComment}
+                    onEditContentChange={setEditCommentContent}
+                    onSaveEdit={handleSaveEditedComment}
+                    onCancelDelete={() => setDeleteTargetCommentId("")}
+                    onConfirmDelete={handleConfirmDeleteComment}
                   />
-                  <button
-                    type="button"
-                    onClick={handleAddComment}
-                    disabled={isSubmittingComment}
-                    className="inline-flex items-center justify-center gap-1.5 rounded-xl bg-rose-500 px-3 py-2 text-xs font-semibold text-white hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60"
-                  >
-                    {isSubmittingComment ? (
-                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                    ) : (
-                      <SendHorizontal className="h-3.5 w-3.5" />
-                    )}
-                    {isSubmittingComment ? "Posting..." : "Post"}
-                  </button>
-                </div>
-              </div>
+                );
+              })}
+          </div>
+
+          <div className="border-t border-slate-100 px-4 py-3">
+            <div className="flex items-end gap-2">
+              <textarea
+                value={newCommentContent}
+                onChange={(event) => setNewCommentContent(event.target.value)}
+                className="flex-1 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800 outline-none focus:border-rose-300 resize-none"
+                rows={2}
+                placeholder="Write a comment..."
+              />
+              <button
+                type="button"
+                onClick={handleAddComment}
+                disabled={isSubmittingComment}
+                className="inline-flex items-center justify-center gap-1.5 rounded-xl bg-rose-500 px-3 py-2 text-xs font-semibold text-white hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60"
+              >
+                {isSubmittingComment ? (
+                  <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                ) : (
+                  <SendHorizontal className="h-3.5 w-3.5" />
+                )}
+                {isSubmittingComment ? "Posting..." : "Post"}
+              </button>
             </div>
           </div>
-        )}
+        </ModalDialog>
 
-        {editingConfessionId && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
-            <button
-              type="button"
-              aria-label="Close edit confession modal"
-              onClick={handleCancelEditConfession}
-              className="absolute inset-0 bg-slate-900/40 backdrop-blur-[2px]"
+        <ModalDialog
+          isOpen={Boolean(editingConfessionId)}
+          onClose={handleCancelEditConfession}
+          title="Edit Confession"
+          titleId={editDialogTitleId}
+          closeLabel="Close edit confession modal"
+          widthClassName="max-w-2xl"
+        >
+          <div className="px-4 py-4 space-y-4">
+            <textarea
+              value={editConfessionContent}
+              onChange={(event) => setEditConfessionContent(event.target.value)}
+              className="w-full min-h-50 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-800 outline-none focus:border-rose-300 resize-none"
+              placeholder="Edit your confession..."
             />
 
-            <div className="relative z-10 w-full max-w-2xl rounded-2xl border border-slate-200 bg-white shadow-xl overflow-hidden">
-              <div className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
-                <h4 className="text-sm sm:text-base font-semibold text-slate-900 truncate pr-4">
-                  Edit Confession
-                </h4>
-                <button
-                  type="button"
-                  onClick={handleCancelEditConfession}
-                  className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-900 transition-colors cursor-pointer"
-                  aria-label="Close edit confession modal"
-                >
-                  <X size={18} />
-                </button>
-              </div>
+            <div className="flex flex-wrap items-center gap-2">
+              <button
+                type="button"
+                onClick={() => setEditConfessionIsAnonymous((prev) => !prev)}
+                aria-pressed={editConfessionIsAnonymous}
+                className="text-xs text-slate-500 inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 cursor-pointer hover:border-slate-400 hover:text-slate-700 transition-colors"
+              >
+                {editConfessionIsAnonymous ? (
+                  <Lock className="w-3.5 h-3.5" />
+                ) : (
+                  <LockOpen className="w-3.5 h-3.5" />
+                )}
+                {editConfessionIsAnonymous ? "Anonymous" : "Identified"}
+              </button>
 
-              <div className="px-4 py-4 space-y-4">
-                <textarea
-                  value={editConfessionContent}
-                  onChange={(event) =>
-                    setEditConfessionContent(event.target.value)
-                  }
-                  className="w-full min-h-50 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-800 outline-none focus:border-rose-300 resize-none"
-                  placeholder="Edit your confession..."
-                />
+              <button
+                type="button"
+                onClick={() =>
+                  setEditConfessionVisibility((prev) =>
+                    prev === "public" ? "private" : "public",
+                  )
+                }
+                aria-pressed={editConfessionVisibility === "private"}
+                className="text-xs text-slate-500 inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 cursor-pointer hover:border-slate-400 hover:text-slate-700 transition-colors"
+              >
+                {editConfessionVisibility === "public" ? (
+                  <Eye className="w-3.5 h-3.5" />
+                ) : (
+                  <EyeOff className="w-3.5 h-3.5" />
+                )}
+                {editConfessionVisibility === "public" ? "Public" : "Private"}
+              </button>
+            </div>
 
-                <div className="flex flex-wrap items-center gap-2">
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setEditConfessionIsAnonymous((prev) => !prev)
-                    }
-                    aria-pressed={editConfessionIsAnonymous}
-                    className="text-xs text-slate-500 inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 cursor-pointer hover:border-slate-400 hover:text-slate-700 transition-colors"
-                  >
-                    {editConfessionIsAnonymous ? (
-                      <Lock className="w-3.5 h-3.5" />
-                    ) : (
-                      <LockOpen className="w-3.5 h-3.5" />
-                    )}
-                    {editConfessionIsAnonymous ? "Anonymous" : "Identified"}
-                  </button>
-
-                  <button
-                    type="button"
-                    onClick={() =>
-                      setEditConfessionVisibility((prev) =>
-                        prev === "public" ? "private" : "public",
-                      )
-                    }
-                    aria-pressed={editConfessionVisibility === "private"}
-                    className="text-xs text-slate-500 inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 cursor-pointer hover:border-slate-400 hover:text-slate-700 transition-colors"
-                  >
-                    {editConfessionVisibility === "public" ? (
-                      <Eye className="w-3.5 h-3.5" />
-                    ) : (
-                      <EyeOff className="w-3.5 h-3.5" />
-                    )}
-                    {editConfessionVisibility === "public"
-                      ? "Public"
-                      : "Private"}
-                  </button>
-                </div>
-
-                <div className="flex items-center justify-end gap-2">
-                  <button
-                    type="button"
-                    onClick={handleCancelEditConfession}
-                    className="px-4 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 cursor-pointer"
-                  >
-                    Cancel
-                  </button>
-                  <button
-                    type="button"
-                    onClick={handleSaveEditedConfession}
-                    disabled={isSubmitting}
-                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60"
-                  >
-                    {isSubmitting ? (
-                      <Loader2 className="h-4 w-4 animate-spin" />
-                    ) : null}
-                    {isSubmitting ? "Updating..." : "Save changes"}
-                  </button>
-                </div>
-              </div>
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={handleCancelEditConfession}
+                className="px-4 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleSaveEditedConfession}
+                disabled={isSubmitting}
+                className="inline-flex items-center justify-center gap-2 rounded-xl bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60"
+              >
+                {isSubmitting ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : null}
+                {isSubmitting ? "Updating..." : "Save changes"}
+              </button>
             </div>
           </div>
-        )}
+        </ModalDialog>
 
-        {deleteTargetConfessionId && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
-            <button
-              type="button"
-              aria-label="Close delete confession modal"
-              onClick={() => setDeleteTargetConfessionId("")}
-              className="absolute inset-0 cursor-default bg-slate-900/40 backdrop-blur-[2px]"
-            />
+        <ModalDialog
+          isOpen={Boolean(deleteTargetConfessionId)}
+          onClose={() => setDeleteTargetConfessionId("")}
+          title="Delete this confession?"
+          titleId={deleteDialogTitleId}
+          closeLabel="Close delete confession modal"
+          widthClassName="max-w-sm"
+        >
+          <div className="p-5">
+            <p className="text-sm text-slate-500 mb-5">
+              This action cannot be undone.
+            </p>
 
-            <div className="relative z-10 w-full max-w-sm bg-white rounded-2xl shadow-xl border border-slate-200 p-5">
-              <h3 className="text-base font-semibold text-slate-900 mb-2">
-                Delete this confession?
-              </h3>
-              <p className="text-sm text-slate-500 mb-5">
-                This action cannot be undone.
-              </p>
-
-              <div className="flex items-center justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={() => setDeleteTargetConfessionId("")}
-                  className="px-4 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 cursor-pointer"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  onClick={handleConfirmDeleteConfession}
-                  className="px-4 py-2 text-sm font-medium rounded-xl bg-rose-500 text-white hover:bg-rose-600 cursor-pointer"
-                >
-                  Delete
-                </button>
-              </div>
+            <div className="flex items-center justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setDeleteTargetConfessionId("")}
+                className="px-4 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 cursor-pointer"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={handleConfirmDeleteConfession}
+                className="px-4 py-2 text-sm font-medium rounded-xl bg-rose-500 text-white hover:bg-rose-600 cursor-pointer"
+              >
+                Delete
+              </button>
             </div>
           </div>
-        )}
+        </ModalDialog>
       </div>
 
       {toast && (

--- a/frontend/src/pages/Confession.jsx
+++ b/frontend/src/pages/Confession.jsx
@@ -15,7 +15,10 @@ import {
   Loader2,
   SendHorizontal,
   X,
+  MoreHorizontal,
 } from "lucide-react";
+
+const normalizeId = (value) => String(value || "").trim();
 
 const parseResponse = async (response) => response.json().catch(() => ({}));
 
@@ -132,6 +135,14 @@ export default function Confession() {
   const [pressedLikeId, setPressedLikeId] = useState(null);
   const [pressedBookmarkId, setPressedBookmarkId] = useState(null);
   const [gestureLikeBurstId, setGestureLikeBurstId] = useState(null);
+  const [editingConfessionId, setEditingConfessionId] = useState("");
+  const [editConfessionContent, setEditConfessionContent] = useState("");
+  const [editConfessionIsAnonymous, setEditConfessionIsAnonymous] =
+    useState(true);
+  const [editConfessionVisibility, setEditConfessionVisibility] =
+    useState("public");
+  const [menuConfessionId, setMenuConfessionId] = useState("");
+  const [deleteTargetConfessionId, setDeleteTargetConfessionId] = useState("");
   const [activeCommentConfessionId, setActiveCommentConfessionId] =
     useState("");
   const [commentModalTitle, setCommentModalTitle] = useState("");
@@ -140,6 +151,17 @@ export default function Confession() {
   const [modalCommentsError, setModalCommentsError] = useState("");
   const sentinelRef = useRef(null);
   const lastTapRef = useRef({ confessionId: "", time: 0 });
+
+  const currentUserId = React.useMemo(() => {
+    try {
+      const currentUser = JSON.parse(
+        localStorage.getItem("currentUser") || "null",
+      );
+      return normalizeId(currentUser?.id || currentUser?._id || "");
+    } catch {
+      return "";
+    }
+  }, []);
 
   const loadConfessions = async ({ cursor = "", append = false } = {}) => {
     if (append) {
@@ -229,6 +251,66 @@ export default function Confession() {
       await loadConfessions();
     } catch (error) {
       setErrorMessage(error.message || "Failed to post confession.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSaveEditedConfession = async () => {
+    if (!editingConfessionId) {
+      return;
+    }
+
+    setErrorMessage("");
+    setSuccessMessage("");
+
+    const cleanedContent = stripTagsFromContent(editConfessionContent);
+
+    if (cleanedContent.length < 5) {
+      setErrorMessage("Write at least 5 characters before updating.");
+      return;
+    }
+
+    const token = localStorage.getItem("token");
+    if (!token) {
+      setErrorMessage("Please log in again to update a confession.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const extractedTags = extractTagsFromContent(editConfessionContent);
+
+      const response = await fetch(`/api/confessions/${editingConfessionId}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          content: cleanedContent,
+          isAnonymous: editConfessionIsAnonymous,
+          visibility: editConfessionVisibility,
+          tags: extractedTags,
+        }),
+      });
+
+      const payload = await parseResponse(response);
+
+      if (!response.ok) {
+        throw new Error(payload?.message || "Failed to update confession.");
+      }
+
+      setEditingConfessionId("");
+      setEditConfessionContent("");
+      setEditConfessionIsAnonymous(true);
+      setEditConfessionVisibility("public");
+      setMenuConfessionId("");
+      setSuccessMessage("Confession updated successfully.");
+      await loadConfessions();
+    } catch (error) {
+      setErrorMessage(error.message || "Failed to update confession.");
     } finally {
       setIsSubmitting(false);
     }
@@ -324,6 +406,90 @@ export default function Confession() {
       );
     } catch (error) {
       setErrorMessage(error.message || "Failed to toggle bookmark.");
+    }
+  };
+
+  const handleToggleConfessionMenu = (confessionId) => {
+    setMenuConfessionId((currentId) =>
+      currentId === confessionId ? "" : confessionId,
+    );
+  };
+
+  const handleEditConfession = (item) => {
+    const existingTags = Array.isArray(item?.tags) ? item.tags : [];
+    const reconstructedEditContent = [
+      item?.content || "",
+      existingTags.map((tag) => `#${tag}`).join(" "),
+    ]
+      .filter(Boolean)
+      .join(" ")
+      .replaceAll(/[ \t]{2,}/g, " ")
+      .trim();
+
+    setMenuConfessionId("");
+    setEditingConfessionId(String(item?._id || item?.id || ""));
+    setEditConfessionContent(reconstructedEditContent);
+    setEditConfessionIsAnonymous(Boolean(item?.isAnonymous));
+    setEditConfessionVisibility(
+      item?.visibility === "private" ? "private" : "public",
+    );
+    setSuccessMessage("");
+    setErrorMessage("");
+  };
+
+  const handleDeleteConfession = (confessionId) => {
+    setMenuConfessionId("");
+    setDeleteTargetConfessionId(confessionId);
+  };
+
+  const handleCancelEditConfession = () => {
+    setEditingConfessionId("");
+    setEditConfessionContent("");
+    setEditConfessionIsAnonymous(true);
+    setEditConfessionVisibility("public");
+  };
+
+  const handleConfirmDeleteConfession = async () => {
+    if (!deleteTargetConfessionId) {
+      return;
+    }
+
+    const confessionId = deleteTargetConfessionId;
+    setDeleteTargetConfessionId("");
+
+    const token = localStorage.getItem("token");
+    if (!token) {
+      setErrorMessage("Please log in again to delete a confession.");
+      return;
+    }
+
+    try {
+      const response = await fetch(`/api/confessions/${confessionId}`, {
+        method: "DELETE",
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      });
+
+      const payload = await parseResponse(response);
+
+      if (!response.ok) {
+        throw new Error(payload?.message || "Failed to delete confession.");
+      }
+
+      setConfessionFeed((prev) =>
+        prev.filter(
+          (item) => String(item?._id || item?.id || "") !== confessionId,
+        ),
+      );
+
+      if (editingConfessionId === confessionId) {
+        handleCancelEditConfession();
+      }
+
+      setSuccessMessage("Confession deleted successfully.");
+    } catch (error) {
+      setErrorMessage(error.message || "Failed to delete confession.");
     }
   };
 
@@ -512,6 +678,8 @@ export default function Confession() {
       const tags =
         Array.isArray(item?.tags) && item.tags.length > 0 ? item.tags : [];
       const confessionId = String(item?._id || item?.id || authorSeed);
+      const canManageConfession =
+        Boolean(currentUserId) && normalizeId(item?.authorId) === currentUserId;
 
       return (
         <div
@@ -520,6 +688,38 @@ export default function Confession() {
           data-liked-by-current-user={Boolean(item?.likedByCurrentUser)}
           className="relative bg-white rounded-2xl sm:rounded-3xl p-5 sm:p-6 mb-5 sm:mb-6 border border-slate-200 shadow-sm transition-all duration-300 hover:shadow-md"
         >
+          {canManageConfession && (
+            <div className="absolute right-4 top-4 z-20">
+              <button
+                type="button"
+                onClick={() => handleToggleConfessionMenu(confessionId)}
+                className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-900 transition-colors cursor-pointer"
+                aria-label="Confession actions"
+              >
+                <MoreHorizontal size={18} />
+              </button>
+
+              {menuConfessionId === confessionId && (
+                <div className="absolute right-0 top-10 w-28 rounded-xl border border-slate-200 bg-white shadow-lg py-1 overflow-hidden">
+                  <button
+                    type="button"
+                    onClick={() => handleEditConfession(item)}
+                    className="w-full px-3 py-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-50"
+                  >
+                    Edit
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => handleDeleteConfession(confessionId)}
+                    className="w-full px-3 py-2 text-left text-xs font-medium text-rose-600 hover:bg-rose-50"
+                  >
+                    Delete
+                  </button>
+                </div>
+              )}
+            </div>
+          )}
+
           {gestureLikeBurstId === confessionId && (
             <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
               <Heart
@@ -541,9 +741,10 @@ export default function Confession() {
                   <h3 className="font-semibold text-slate-900 truncate">
                     {author}
                   </h3>
-                  <span className="text-slate-400 text-xs">
-                    • {getRelativeTime(item?.createdAt)}
-                  </span>
+                  <div className="flex items-center gap-1 text-xs text-slate-400">
+                    <span>• {getRelativeTime(item?.createdAt)}</span>
+                    {item?.isEdited ? <span>• Edited</span> : null}
+                  </div>
                 </div>
               </div>
             </div>
@@ -632,7 +833,7 @@ export default function Confession() {
 
         <main className="flex-1 min-h-0 overflow-hidden">
           <div className="h-full overflow-y-auto pt-6 sm:pt-8 lg:pt-10 px-3 sm:px-5 lg:px-6 pb-8 sm:pb-10 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-            <div className="max-w-4xl flex flex-col items-center justify-start">
+            <div className="max-w-4xl mx-auto flex flex-col items-center justify-start">
               {errorMessage && (
                 <div className="w-full mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
                   {errorMessage}
@@ -699,19 +900,13 @@ export default function Confession() {
                       ) : (
                         <SendHorizontal className="h-4 w-4" />
                       )}
-                      {isSubmitting ? "Posting..." : "Post"}
+                      Post
                     </button>
                   </div>
                 </div>
               </div>
 
-              <div className="mt-8 w-full">
-                <div className="mb-4 flex items-center justify-between">
-                  <h3 className="text-xl sm:text-2xl font-semibold text-slate-900">
-                    Confession Feed
-                  </h3>
-                </div>
-
+              <div className="mt-8 w-full pt-4 border-t border-gray-300">
                 {feedContent}
 
                 {isLoadingMoreFeed && (
@@ -804,6 +999,133 @@ export default function Confession() {
                       </div>
                     );
                   })}
+              </div>
+            </div>
+          </div>
+        )}
+
+        {editingConfessionId && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-[2px] px-4 py-6">
+            <div className="w-full max-w-2xl rounded-2xl border border-slate-200 bg-white shadow-xl overflow-hidden">
+              <div className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
+                <h4 className="text-sm sm:text-base font-semibold text-slate-900 truncate pr-4">
+                  Edit Confession
+                </h4>
+                <button
+                  type="button"
+                  onClick={handleCancelEditConfession}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-900 transition-colors cursor-pointer"
+                  aria-label="Close edit confession modal"
+                >
+                  <X size={18} />
+                </button>
+              </div>
+
+              <div className="px-4 py-4 space-y-4">
+                <textarea
+                  value={editConfessionContent}
+                  onChange={(event) =>
+                    setEditConfessionContent(event.target.value)
+                  }
+                  className="w-full min-h-50 rounded-2xl border border-slate-200 bg-slate-50 px-4 py-3 text-sm text-slate-800 outline-none focus:border-rose-300 resize-none"
+                  placeholder="Edit your confession..."
+                />
+
+                <div className="flex flex-wrap items-center gap-2">
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setEditConfessionIsAnonymous((prev) => !prev)
+                    }
+                    aria-pressed={editConfessionIsAnonymous}
+                    className="text-xs text-slate-500 inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 cursor-pointer hover:border-slate-400 hover:text-slate-700 transition-colors"
+                  >
+                    {editConfessionIsAnonymous ? (
+                      <Lock className="w-3.5 h-3.5" />
+                    ) : (
+                      <LockOpen className="w-3.5 h-3.5" />
+                    )}
+                    {editConfessionIsAnonymous ? "Anonymous" : "Identified"}
+                  </button>
+
+                  <button
+                    type="button"
+                    onClick={() =>
+                      setEditConfessionVisibility((prev) =>
+                        prev === "public" ? "private" : "public",
+                      )
+                    }
+                    aria-pressed={editConfessionVisibility === "private"}
+                    className="text-xs text-slate-500 inline-flex items-center gap-2 rounded-full border border-slate-200 px-3 py-1.5 cursor-pointer hover:border-slate-400 hover:text-slate-700 transition-colors"
+                  >
+                    {editConfessionVisibility === "public" ? (
+                      <Eye className="w-3.5 h-3.5" />
+                    ) : (
+                      <EyeOff className="w-3.5 h-3.5" />
+                    )}
+                    {editConfessionVisibility === "public"
+                      ? "Public"
+                      : "Private"}
+                  </button>
+                </div>
+
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={handleCancelEditConfession}
+                    className="px-4 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 cursor-pointer"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleSaveEditedConfession}
+                    disabled={isSubmitting}
+                    className="inline-flex items-center justify-center gap-2 rounded-xl bg-rose-500 px-4 py-2 text-sm font-semibold text-white hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60"
+                  >
+                    {isSubmitting ? (
+                      <Loader2 className="h-4 w-4 animate-spin" />
+                    ) : null}
+                    {isSubmitting ? "Updating..." : "Save changes"}
+                  </button>
+                </div>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {deleteTargetConfessionId && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center p-4">
+            <button
+              type="button"
+              aria-label="Close delete confession modal"
+              onClick={() => setDeleteTargetConfessionId("")}
+              className="absolute inset-0 cursor-default bg-slate-900/40 backdrop-blur-[2px]"
+            />
+
+            <div className="relative z-10 w-full max-w-sm bg-white rounded-2xl shadow-xl border border-slate-200 p-5">
+              <h3 className="text-base font-semibold text-slate-900 mb-2">
+                Delete this confession?
+              </h3>
+              <p className="text-sm text-slate-500 mb-5">
+                This action cannot be undone.
+              </p>
+
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={() => setDeleteTargetConfessionId("")}
+                  className="px-4 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 cursor-pointer"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={handleConfirmDeleteConfession}
+                  className="px-4 py-2 text-sm font-medium rounded-xl bg-rose-500 text-white hover:bg-rose-600 cursor-pointer"
+                >
+                  Delete
+                </button>
               </div>
             </div>
           </div>

--- a/frontend/src/pages/Confession.jsx
+++ b/frontend/src/pages/Confession.jsx
@@ -306,15 +306,39 @@ export default function Confession() {
     [showToast],
   );
 
-  const currentUserId = React.useMemo(() => {
-    try {
-      const currentUser = JSON.parse(
-        localStorage.getItem("currentUser") || "null",
-      );
-      return normalizeId(currentUser?.id || currentUser?._id || "");
-    } catch {
-      return "";
-    }
+  const [currentUserId, setCurrentUserId] = React.useState("");
+
+  React.useEffect(() => {
+    const syncCurrentUserId = () => {
+      try {
+        const currentUser = JSON.parse(
+          localStorage.getItem("currentUser") || "null",
+        );
+
+        setCurrentUserId(
+          normalizeId(currentUser?.id || currentUser?._id || ""),
+        );
+      } catch {
+        setCurrentUserId("");
+      }
+    };
+
+    const handleStorage = (event) => {
+      if (event.key && event.key !== "currentUser") {
+        return;
+      }
+
+      syncCurrentUserId();
+    };
+
+    syncCurrentUserId();
+    window.addEventListener("storage", handleStorage);
+    window.addEventListener("focus", syncCurrentUserId);
+
+    return () => {
+      window.removeEventListener("storage", handleStorage);
+      window.removeEventListener("focus", syncCurrentUserId);
+    };
   }, []);
 
   const {
@@ -334,8 +358,10 @@ export default function Confession() {
     isDeletingComment,
     isLoadingModalComments,
     modalCommentsError,
+    modalCommentsHasMore,
     closeCommentModal: closeCommentModalState,
     openCommentModal: openCommentModalState,
+    loadMoreModalComments,
     handleAddComment,
     handleToggleCommentMenu,
     handleStartEditComment,
@@ -953,7 +979,7 @@ export default function Confession() {
                   <textarea
                     value={confession}
                     onChange={(e) => setConfession(e.target.value)}
-                    className="bg-transparent border-none outline-none w-full h-32 text-base text-md text-slate-200 resize-none placeholder:text-slate-400"
+                    className="bg-transparent border-none outline-none w-full h-32 text-base text-slate-200 resize-none placeholder:text-slate-400"
                     placeholder="Write your confession..."
                   />
                   <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-4 mt-2">
@@ -1031,11 +1057,11 @@ export default function Confession() {
           widthClassName="max-w-xl"
         >
           <div className="max-h-[65vh] overflow-y-auto px-4 py-4 space-y-3">
-            {isLoadingModalComments && (
+            {isLoadingModalComments && modalComments.length === 0 && (
               <p className="text-sm text-slate-500">Loading comments...</p>
             )}
 
-            {!isLoadingModalComments && modalCommentsError && (
+            {modalCommentsError && (
               <p className="text-sm text-rose-600">{modalCommentsError}</p>
             )}
 
@@ -1045,8 +1071,7 @@ export default function Confession() {
                 <p className="text-sm text-slate-500">No comments yet.</p>
               )}
 
-            {!isLoadingModalComments &&
-              !modalCommentsError &&
+            {!modalCommentsError &&
               modalComments.map((comment) => {
                 return (
                   <ConfessionModalCommentItem
@@ -1070,6 +1095,19 @@ export default function Confession() {
                   />
                 );
               })}
+
+            {modalCommentsHasMore && !modalCommentsError && (
+              <div className="flex justify-center pt-1">
+                <button
+                  type="button"
+                  onClick={loadMoreModalComments}
+                  disabled={isLoadingModalComments}
+                  className="rounded-full border border-slate-200 px-4 py-2 text-sm font-medium text-slate-700 transition-colors hover:border-slate-300 hover:text-slate-900 disabled:cursor-not-allowed disabled:opacity-60"
+                >
+                  {isLoadingModalComments ? "Loading..." : "Load more"}
+                </button>
+              </div>
+            )}
           </div>
 
           <div className="border-t border-slate-100 px-4 py-3">

--- a/frontend/src/pages/Confession.jsx
+++ b/frontend/src/pages/Confession.jsx
@@ -8,137 +8,28 @@ import {
   LockOpen,
   Eye,
   EyeOff,
-  Heart,
-  MessageCircle,
-  Bookmark,
-  Share2,
   Loader2,
   SendHorizontal,
   X,
-  MoreHorizontal,
+  CheckCircle2,
+  AlertCircle,
 } from "lucide-react";
-
-const normalizeId = (value) => String(value || "").trim();
-
-const parseResponse = async (response) => response.json().catch(() => ({}));
-
-const formatCount = (value) => {
-  if (value >= 1000000) {
-    return `${(value / 1000000).toFixed(1).replace(/\.0$/, "")}M`;
-  }
-
-  if (value >= 1000) {
-    return `${(value / 1000).toFixed(1).replace(/\.0$/, "")}K`;
-  }
-
-  return String(value);
-};
-
-const RELATIVE_TIME_STEPS = [
-  { limitMinutes: 1, toLabel: () => "Just now" },
-  {
-    limitMinutes: 60,
-    toLabel: (minutes) => `${minutes} minute${minutes > 1 ? "s" : ""} ago`,
-  },
-  {
-    limitMinutes: 24 * 60,
-    toLabel: (minutes) => {
-      const hours = Math.floor(minutes / 60);
-      return `${hours} hour${hours > 1 ? "s" : ""} ago`;
-    },
-  },
-  {
-    limitMinutes: 7 * 24 * 60,
-    toLabel: (minutes) => {
-      const days = Math.floor(minutes / (24 * 60));
-      return `${days} day${days > 1 ? "s" : ""} ago`;
-    },
-  },
-  {
-    limitMinutes: 5 * 7 * 24 * 60,
-    toLabel: (minutes) => {
-      const weeks = Math.floor(minutes / (7 * 24 * 60));
-      return `${weeks} week${weeks > 1 ? "s" : ""} ago`;
-    },
-  },
-  {
-    limitMinutes: 12 * 30 * 24 * 60,
-    toLabel: (minutes) => {
-      const months = Math.floor(minutes / (30 * 24 * 60));
-      return `${months} month${months > 1 ? "s" : ""} ago`;
-    },
-  },
-];
-
-const getRelativeTime = (dateString) => {
-  const sourceDate = new Date(dateString);
-
-  if (Number.isNaN(sourceDate.getTime())) {
-    return "Recently";
-  }
-
-  const diffMs = Date.now() - sourceDate.getTime();
-  const diffMinutes = Math.floor(diffMs / (1000 * 60));
-
-  for (const step of RELATIVE_TIME_STEPS) {
-    if (diffMinutes < step.limitMinutes) {
-      return step.toLabel(diffMinutes);
-    }
-  }
-
-  const diffYears = Math.floor(diffMinutes / (365 * 24 * 60));
-  return `${diffYears} year${diffYears > 1 ? "s" : ""} ago`;
-};
-
-const CONFESSION_FEED_LIMIT = 8;
-const CONFESSION_CONTENT_PREVIEW_LIMIT = 280;
-
-const extractTagsFromContent = (content) => {
-  const matches = content.match(/#\w+/g) || [];
-  const uniqueByLowercase = new Map();
-
-  for (const rawTag of matches) {
-    const cleanedTag = rawTag.slice(1).trim();
-
-    if (!cleanedTag) {
-      continue;
-    }
-
-    const normalizedKey = cleanedTag.toLowerCase();
-
-    if (!uniqueByLowercase.has(normalizedKey)) {
-      uniqueByLowercase.set(normalizedKey, cleanedTag);
-    }
-  }
-
-  return Array.from(uniqueByLowercase.values());
-};
-
-const stripTagsFromContent = (content) =>
-  content
-    .replaceAll(/#\w+/g, "")
-    .replaceAll(/[ \t]{2,}/g, " ")
-    .replaceAll(/\n{3,}/g, "\n\n")
-    .trim();
-
-const getConfessionContentPreview = (content, isExpanded) => {
-  const safeContent = content || "No confession content";
-  const isLongContent = safeContent.length > CONFESSION_CONTENT_PREVIEW_LIMIT;
-
-  if (!isLongContent || isExpanded) {
-    return {
-      visibleContent: safeContent,
-      isLongContent,
-    };
-  }
-
-  return {
-    visibleContent: `${safeContent.slice(0, CONFESSION_CONTENT_PREVIEW_LIMIT)}...`,
-    isLongContent,
-  };
-};
+import {
+  normalizeId,
+  parseResponse,
+  CONFESSION_FEED_LIMIT,
+  extractTagsFromContent,
+  stripTagsFromContent,
+} from "./confession/confessionUtils";
+import { useOutsideClickCloser } from "./confession/useOutsideClickCloser";
+import { useConfessionComments } from "./confession/useConfessionComments";
+import ConfessionFeedCard from "./confession/ConfessionFeedCard";
+import ConfessionModalCommentItem from "./confession/ConfessionModalCommentItem";
 
 export default function Confession() {
+  // NOSONAR
+  const TOAST_DURATION_MS = 3200;
+  const TOAST_EXIT_MS = 220;
   const [confession, setConfession] = useState("");
   const [isAnonymous, setIsAnonymous] = useState(true);
   const [visibility, setVisibility] = useState("public");
@@ -148,8 +39,7 @@ export default function Confession() {
   const [isLoadingFeed, setIsLoadingFeed] = useState(true);
   const [isLoadingMoreFeed, setIsLoadingMoreFeed] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
-  const [errorMessage, setErrorMessage] = useState("");
-  const [successMessage, setSuccessMessage] = useState("");
+  const [toast, setToast] = useState(null);
   const [pressedLikeId, setPressedLikeId] = useState(null);
   const [pressedBookmarkId, setPressedBookmarkId] = useState(null);
   const [gestureLikeBurstId, setGestureLikeBurstId] = useState(null);
@@ -162,14 +52,82 @@ export default function Confession() {
   const [menuConfessionId, setMenuConfessionId] = useState("");
   const [expandedConfessionIds, setExpandedConfessionIds] = useState({});
   const [deleteTargetConfessionId, setDeleteTargetConfessionId] = useState("");
-  const [activeCommentConfessionId, setActiveCommentConfessionId] =
-    useState("");
-  const [commentModalTitle, setCommentModalTitle] = useState("");
-  const [modalComments, setModalComments] = useState([]);
-  const [isLoadingModalComments, setIsLoadingModalComments] = useState(false);
-  const [modalCommentsError, setModalCommentsError] = useState("");
   const sentinelRef = useRef(null);
   const lastTapRef = useRef({ confessionId: "", time: 0 });
+  const toastTimeoutRef = useRef(null);
+  const toastExitTimeoutRef = useRef(null);
+  const [isToastVisible, setIsToastVisible] = useState(false);
+
+  const hideToast = React.useCallback(() => {
+    setIsToastVisible(false);
+
+    if (toastExitTimeoutRef.current) {
+      clearTimeout(toastExitTimeoutRef.current);
+    }
+
+    toastExitTimeoutRef.current = setTimeout(() => {
+      setToast(null);
+      toastExitTimeoutRef.current = null;
+    }, TOAST_EXIT_MS);
+  }, [TOAST_EXIT_MS]);
+
+  const dismissToast = React.useCallback(() => {
+    if (toastTimeoutRef.current) {
+      clearTimeout(toastTimeoutRef.current);
+      toastTimeoutRef.current = null;
+    }
+
+    hideToast();
+  }, [hideToast]);
+
+  const showToast = React.useCallback(
+    (type, message) => {
+      if (!message) {
+        return;
+      }
+
+      if (toastTimeoutRef.current) {
+        clearTimeout(toastTimeoutRef.current);
+      }
+
+      if (toastExitTimeoutRef.current) {
+        clearTimeout(toastExitTimeoutRef.current);
+        toastExitTimeoutRef.current = null;
+      }
+
+      setToast({
+        id: `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`,
+        type,
+        message,
+      });
+
+      setIsToastVisible(false);
+
+      requestAnimationFrame(() => {
+        setIsToastVisible(true);
+      });
+
+      toastTimeoutRef.current = setTimeout(() => {
+        hideToast();
+        toastTimeoutRef.current = null;
+      }, TOAST_DURATION_MS);
+    },
+    [TOAST_DURATION_MS, hideToast],
+  );
+
+  const showError = React.useCallback(
+    (message) => {
+      showToast("error", message);
+    },
+    [showToast],
+  );
+
+  const showSuccess = React.useCallback(
+    (message) => {
+      showToast("success", message);
+    },
+    [showToast],
+  );
 
   const currentUserId = React.useMemo(() => {
     try {
@@ -182,61 +140,91 @@ export default function Confession() {
     }
   }, []);
 
-  const loadConfessions = async ({ cursor = "", append = false } = {}) => {
-    if (append) {
-      setIsLoadingMoreFeed(true);
-    } else {
-      setIsLoadingFeed(true);
-    }
+  const {
+    activeCommentConfessionId,
+    commentModalTitle,
+    modalComments,
+    newCommentContent,
+    setNewCommentContent,
+    isSubmittingComment,
+    activeCommentMenuId,
+    editingCommentId,
+    editCommentContent,
+    setEditCommentContent,
+    isSavingEditedComment,
+    deleteTargetCommentId,
+    setDeleteTargetCommentId,
+    isDeletingComment,
+    isLoadingModalComments,
+    modalCommentsError,
+    closeCommentModal,
+    openCommentModal,
+    handleAddComment,
+    handleToggleCommentMenu,
+    handleStartEditComment,
+    handleCancelEditComment,
+    handleSaveEditedComment,
+    handleDeleteComment,
+    handleConfirmDeleteComment,
+  } = useConfessionComments({ setConfessionFeed });
 
-    try {
-      const params = new URLSearchParams({
-        limit: String(CONFESSION_FEED_LIMIT),
-      });
-
-      if (cursor) {
-        params.set("cursor", cursor);
+  const loadConfessions = React.useCallback(
+    async ({ cursor = "", append = false } = {}) => {
+      if (append) {
+        setIsLoadingMoreFeed(true);
+      } else {
+        setIsLoadingFeed(true);
       }
 
-      const token = localStorage.getItem("token");
-      const headers = token ? { Authorization: `Bearer ${token}` } : {};
+      try {
+        const params = new URLSearchParams({
+          limit: String(CONFESSION_FEED_LIMIT),
+        });
 
-      const response = await fetch(`/api/confessions?${params.toString()}`, {
-        headers,
-      });
-      const payload = await parseResponse(response);
+        if (cursor) {
+          params.set("cursor", cursor);
+        }
 
-      if (!response.ok) {
-        throw new Error(payload?.message || "Failed to load confessions.");
+        const token = localStorage.getItem("token");
+        const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+        const response = await fetch(`/api/confessions?${params.toString()}`, {
+          headers,
+        });
+        const payload = await parseResponse(response);
+
+        if (!response.ok) {
+          throw new Error(payload?.message || "Failed to load confessions.");
+        }
+
+        const data = Array.isArray(payload?.data) ? payload.data : [];
+
+        setConfessionFeed((prev) => (append ? [...prev, ...data] : data));
+        setNextCursor(payload?.nextCursor || "");
+        setHasMoreFeed(Boolean(payload?.hasMore));
+      } catch (error) {
+        showError(error.message || "Failed to load confessions.");
+      } finally {
+        setIsLoadingFeed(false);
+        setIsLoadingMoreFeed(false);
       }
-
-      const data = Array.isArray(payload?.data) ? payload.data : [];
-
-      setConfessionFeed((prev) => (append ? [...prev, ...data] : data));
-      setNextCursor(payload?.nextCursor || "");
-      setHasMoreFeed(Boolean(payload?.hasMore));
-    } catch (error) {
-      setErrorMessage(error.message || "Failed to load confessions.");
-    } finally {
-      setIsLoadingFeed(false);
-      setIsLoadingMoreFeed(false);
-    }
-  };
+    },
+    [showError],
+  );
 
   const handleSubmit = async () => {
-    setErrorMessage("");
-    setSuccessMessage("");
+    dismissToast();
 
     const cleanedContent = stripTagsFromContent(confession);
 
     if (cleanedContent.length < 5) {
-      setErrorMessage("Write at least 5 characters before posting.");
+      showError("Write at least 5 characters before posting.");
       return;
     }
 
     const token = localStorage.getItem("token");
     if (!token) {
-      setErrorMessage("Please log in again to post a confession.");
+      showError("Please log in again to post a confession.");
       return;
     }
 
@@ -266,10 +254,10 @@ export default function Confession() {
       }
 
       setConfession("");
-      setSuccessMessage("Confession posted successfully.");
+      showSuccess("Confession posted successfully.");
       await loadConfessions();
     } catch (error) {
-      setErrorMessage(error.message || "Failed to post confession.");
+      showError(error.message || "Failed to post confession.");
     } finally {
       setIsSubmitting(false);
     }
@@ -280,19 +268,18 @@ export default function Confession() {
       return;
     }
 
-    setErrorMessage("");
-    setSuccessMessage("");
+    dismissToast();
 
     const cleanedContent = stripTagsFromContent(editConfessionContent);
 
     if (cleanedContent.length < 5) {
-      setErrorMessage("Write at least 5 characters before updating.");
+      showError("Write at least 5 characters before updating.");
       return;
     }
 
     const token = localStorage.getItem("token");
     if (!token) {
-      setErrorMessage("Please log in again to update a confession.");
+      showError("Please log in again to update a confession.");
       return;
     }
 
@@ -326,66 +313,69 @@ export default function Confession() {
       setEditConfessionIsAnonymous(true);
       setEditConfessionVisibility("public");
       setMenuConfessionId("");
-      setSuccessMessage("Confession updated successfully.");
+      showSuccess("Confession updated successfully.");
       await loadConfessions();
     } catch (error) {
-      setErrorMessage(error.message || "Failed to update confession.");
+      showError(error.message || "Failed to update confession.");
     } finally {
       setIsSubmitting(false);
     }
   };
 
-  const handleToggleLike = React.useCallback(async (confessionId) => {
-    const token = localStorage.getItem("token");
-    if (!token) {
-      setErrorMessage("Please log in to like confessions.");
-      return;
-    }
-
-    setPressedLikeId(confessionId);
-    setTimeout(() => {
-      setPressedLikeId((currentId) =>
-        currentId === confessionId ? null : currentId,
-      );
-    }, 150);
-
-    try {
-      const response = await fetch(
-        `/api/confessions/${confessionId}/toggle-like`,
-        {
-          method: "POST",
-          headers: {
-            Authorization: `Bearer ${token}`,
-          },
-        },
-      );
-
-      if (!response.ok) {
-        throw new Error("Failed to toggle like.");
+  const handleToggleLike = React.useCallback(
+    async (confessionId) => {
+      const token = localStorage.getItem("token");
+      if (!token) {
+        showError("Please log in to like confessions.");
+        return;
       }
 
-      const payload = await parseResponse(response);
+      setPressedLikeId(confessionId);
+      setTimeout(() => {
+        setPressedLikeId((currentId) =>
+          currentId === confessionId ? null : currentId,
+        );
+      }, 150);
 
-      setConfessionFeed((prev) =>
-        prev.map((item) =>
-          item._id === confessionId || item.id === confessionId
-            ? {
-                ...item,
-                likedByCurrentUser: Boolean(payload.likedByCurrentUser),
-                likesCount: Number(payload.likesCount || 0),
-              }
-            : item,
-        ),
-      );
-    } catch (error) {
-      setErrorMessage(error.message || "Failed to toggle like.");
-    }
-  }, []);
+      try {
+        const response = await fetch(
+          `/api/confessions/${confessionId}/toggle-like`,
+          {
+            method: "POST",
+            headers: {
+              Authorization: `Bearer ${token}`,
+            },
+          },
+        );
+
+        if (!response.ok) {
+          throw new Error("Failed to toggle like.");
+        }
+
+        const payload = await parseResponse(response);
+
+        setConfessionFeed((prev) =>
+          prev.map((item) =>
+            item._id === confessionId || item.id === confessionId
+              ? {
+                  ...item,
+                  likedByCurrentUser: Boolean(payload.likedByCurrentUser),
+                  likesCount: Number(payload.likesCount || 0),
+                }
+              : item,
+          ),
+        );
+      } catch (error) {
+        showError(error.message || "Failed to toggle like.");
+      }
+    },
+    [showError],
+  );
 
   const handleToggleBookmark = async (confessionId) => {
     const token = localStorage.getItem("token");
     if (!token) {
-      setErrorMessage("Please log in to bookmark confessions.");
+      showError("Please log in to bookmark confessions.");
       return;
     }
 
@@ -424,7 +414,7 @@ export default function Confession() {
         ),
       );
     } catch (error) {
-      setErrorMessage(error.message || "Failed to toggle bookmark.");
+      showError(error.message || "Failed to toggle bookmark.");
     }
   };
 
@@ -459,8 +449,7 @@ export default function Confession() {
     setEditConfessionVisibility(
       item?.visibility === "private" ? "private" : "public",
     );
-    setSuccessMessage("");
-    setErrorMessage("");
+    dismissToast();
   };
 
   const handleDeleteConfession = (confessionId) => {
@@ -485,7 +474,7 @@ export default function Confession() {
 
     const token = localStorage.getItem("token");
     if (!token) {
-      setErrorMessage("Please log in again to delete a confession.");
+      showError("Please log in again to delete a confession.");
       return;
     }
 
@@ -513,9 +502,9 @@ export default function Confession() {
         handleCancelEditConfession();
       }
 
-      setSuccessMessage("Confession deleted successfully.");
+      showSuccess("Confession deleted successfully.");
     } catch (error) {
-      setErrorMessage(error.message || "Failed to delete confession.");
+      showError(error.message || "Failed to delete confession.");
     }
   };
 
@@ -536,43 +525,6 @@ export default function Confession() {
     },
     [handleToggleLike],
   );
-
-  const closeCommentModal = () => {
-    setActiveCommentConfessionId("");
-    setCommentModalTitle("");
-    setModalComments([]);
-    setModalCommentsError("");
-    setIsLoadingModalComments(false);
-  };
-
-  const openCommentModal = async (confessionId, authorName) => {
-    setActiveCommentConfessionId(confessionId);
-    setCommentModalTitle(authorName || "Confession");
-    setModalComments([]);
-    setModalCommentsError("");
-    setIsLoadingModalComments(true);
-
-    try {
-      const token = localStorage.getItem("token");
-      const headers = token ? { Authorization: `Bearer ${token}` } : {};
-      const response = await fetch(
-        `/api/confessions/${confessionId}/comments?limit=10`,
-        { headers },
-      );
-      const payload = await parseResponse(response);
-
-      if (!response.ok) {
-        throw new Error(payload?.message || "Failed to load comments.");
-      }
-
-      const comments = Array.isArray(payload?.comments) ? payload.comments : [];
-      setModalComments(comments);
-    } catch (error) {
-      setModalCommentsError(error.message || "Failed to load comments.");
-    } finally {
-      setIsLoadingModalComments(false);
-    }
-  };
 
   React.useEffect(() => {
     const getCardMeta = (eventTarget) => {
@@ -644,33 +596,27 @@ export default function Confession() {
   }, [handleCardLikeGesture]);
 
   React.useEffect(() => {
-    void loadConfessions();
-  }, []);
+    loadConfessions().catch(() => {});
+  }, [loadConfessions]);
 
-  React.useEffect(() => {
-    if (!menuConfessionId) {
-      return undefined;
-    }
-
-    const handleClickOutsideMenu = (event) => {
-      if (
-        event.target instanceof Element &&
-        event.target.closest("[data-confession-menu]")
-      ) {
-        return;
+  React.useEffect(
+    () => () => {
+      if (toastTimeoutRef.current) {
+        clearTimeout(toastTimeoutRef.current);
       }
 
-      setMenuConfessionId("");
-    };
+      if (toastExitTimeoutRef.current) {
+        clearTimeout(toastExitTimeoutRef.current);
+      }
+    },
+    [],
+  );
 
-    document.addEventListener("mousedown", handleClickOutsideMenu);
-    document.addEventListener("touchstart", handleClickOutsideMenu);
-
-    return () => {
-      document.removeEventListener("mousedown", handleClickOutsideMenu);
-      document.removeEventListener("touchstart", handleClickOutsideMenu);
-    };
-  }, [menuConfessionId]);
+  useOutsideClickCloser(
+    Boolean(menuConfessionId),
+    () => setMenuConfessionId(""),
+    "[data-confession-menu]",
+  );
 
   React.useEffect(() => {
     const observer = new IntersectionObserver(
@@ -681,7 +627,7 @@ export default function Confession() {
           !isLoadingMoreFeed &&
           !isLoadingFeed
         ) {
-          void loadConfessions({ cursor: nextCursor, append: true });
+          loadConfessions({ cursor: nextCursor, append: true }).catch(() => {});
         }
       },
       { threshold: 0.1 },
@@ -698,7 +644,13 @@ export default function Confession() {
         observer.unobserve(currentSentinel);
       }
     };
-  }, [hasMoreFeed, nextCursor, isLoadingMoreFeed, isLoadingFeed]);
+  }, [
+    hasMoreFeed,
+    nextCursor,
+    isLoadingMoreFeed,
+    isLoadingFeed,
+    loadConfessions,
+  ]);
 
   let feedContent = null;
   const isCommentModalOpen = Boolean(activeCommentConfessionId);
@@ -716,180 +668,25 @@ export default function Confession() {
       </div>
     );
   } else {
-    feedContent = confessionFeed.map((item) => {
-      const originalAuthor = item?.authorDisplayName || "Unknown Author";
-      const author = item?.isAnonymous ? "Anonymous" : originalAuthor;
-      const authorSeed = String(author || "author");
-      const avatarSrc =
-        !item?.isAnonymous && item?.authorProfilePicture
-          ? item.authorProfilePicture
-          : `https://api.dicebear.com/7.x/bottts/svg?seed=${encodeURIComponent(
-              authorSeed,
-            )}`;
-      const tags =
-        Array.isArray(item?.tags) && item.tags.length > 0 ? item.tags : [];
-      const confessionId = String(item?._id || item?.id || authorSeed);
-      const canManageConfession =
-        Boolean(currentUserId) && normalizeId(item?.authorId) === currentUserId;
-      const isExpanded = Boolean(expandedConfessionIds[confessionId]);
-      const { visibleContent, isLongContent } = getConfessionContentPreview(
-        item?.content,
-        isExpanded,
-      );
-
-      return (
-        <div
-          key={confessionId}
-          data-confession-card-id={confessionId}
-          data-liked-by-current-user={Boolean(item?.likedByCurrentUser)}
-          className="relative bg-white rounded-2xl sm:rounded-3xl p-5 sm:p-6 mb-5 sm:mb-6 border border-slate-200 shadow-sm transition-all duration-300 hover:shadow-md"
-        >
-          {canManageConfession && (
-            <div className="absolute right-4 top-4 z-20" data-confession-menu>
-              <button
-                type="button"
-                onClick={() => handleToggleConfessionMenu(confessionId)}
-                className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-900 transition-colors cursor-pointer"
-                aria-label="Confession actions"
-              >
-                <MoreHorizontal size={18} />
-              </button>
-
-              {menuConfessionId === confessionId && (
-                <div className="absolute right-0 top-10 w-28 rounded-xl border border-slate-200 bg-white shadow-lg py-1 overflow-hidden">
-                  <button
-                    type="button"
-                    onClick={() => handleEditConfession(item)}
-                    className="w-full px-3 py-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-50"
-                  >
-                    Edit
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => handleDeleteConfession(confessionId)}
-                    className="w-full px-3 py-2 text-left text-xs font-medium text-rose-600 hover:bg-rose-50"
-                  >
-                    Delete
-                  </button>
-                </div>
-              )}
-            </div>
-          )}
-
-          {gestureLikeBurstId === confessionId && (
-            <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
-              <Heart
-                size={56}
-                className="text-rose-500/90 animate-pulse"
-                fill="currentColor"
-              />
-            </div>
-          )}
-
-          <div className="flex justify-between items-start mb-4">
-            <div className="flex items-center gap-3 min-w-0">
-              <div className="w-10 h-10 rounded-full bg-slate-200 overflow-hidden">
-                <img src={avatarSrc} alt="avatar" />
-              </div>
-
-              <div className="min-w-0">
-                <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
-                  <h3 className="font-semibold text-slate-900 truncate">
-                    {author}
-                  </h3>
-                  <div className="flex items-center gap-1 text-xs text-slate-400">
-                    <span>• {getRelativeTime(item?.createdAt)}</span>
-                    {item?.isEdited ? <span>• Edited</span> : null}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </div>
-
-          <p className="text-slate-600 text-sm leading-relaxed whitespace-pre-wrap">
-            {visibleContent}
-          </p>
-
-          {isLongContent && (
-            <button
-              type="button"
-              onClick={() => handleToggleExpandedConfession(confessionId)}
-              className="mt-2 mb-6 text-xs font-semibold text-slate-500 hover:underline cursor-pointer"
-            >
-              {isExpanded ? "Show less" : "Show more"}
-            </button>
-          )}
-
-          {!isLongContent && <div className="mb-6" />}
-
-          {tags.length > 0 && (
-            <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1">
-              {tags.slice(0, 4).map((tag) => (
-                <button
-                  key={`${confessionId}-${tag}`}
-                  type="button"
-                  className="text-xs font-semibold tracking-wide text-rose-600 hover:underline cursor-pointer"
-                >
-                  #{tag}
-                </button>
-              ))}
-            </div>
-          )}
-
-          <div className="flex items-center justify-between gap-3 pt-4 border-t border-slate-100">
-            <div className="flex items-center gap-3 min-w-0">
-              <div className="relative">
-                <button
-                  onClick={() => handleToggleLike(confessionId)}
-                  className={`flex items-center gap-2 transition-all duration-200 cursor-pointer ${
-                    item?.likedByCurrentUser
-                      ? "text-rose-500"
-                      : "text-slate-500 hover:text-rose-500"
-                  } ${pressedLikeId === confessionId ? "scale-95" : "scale-100"}`}
-                >
-                  <Heart
-                    size={20}
-                    fill={item?.likedByCurrentUser ? "currentColor" : "none"}
-                  />
-                  <span className="text-xs sm:text-sm font-medium">
-                    {formatCount(Number(item?.likesCount || 0))}
-                  </span>
-                </button>
-              </div>
-
-              <button
-                onClick={() => openCommentModal(confessionId, author)}
-                className="flex items-center gap-2 text-slate-500 transition-all duration-200 hover:text-sky-500 cursor-pointer"
-              >
-                <MessageCircle size={20} />
-                <span className="text-xs sm:text-sm font-medium">
-                  {formatCount(Number(item?.commentCount || 0))}
-                </span>
-              </button>
-            </div>
-
-            <div className="flex items-center gap-3 shrink-0">
-              <button
-                onClick={() => handleToggleBookmark(confessionId)}
-                className={`transition-colors cursor-pointer ${
-                  item?.savedByCurrentUser
-                    ? "text-rose-500"
-                    : "text-slate-500 hover:text-rose-500"
-                } ${pressedBookmarkId === confessionId ? "scale-95" : "scale-100"}`}
-              >
-                <Bookmark
-                  size={20}
-                  fill={item?.savedByCurrentUser ? "currentColor" : "none"}
-                />
-              </button>
-              <button className="text-slate-500 hover:text-slate-900 transition-colors cursor-pointer">
-                <Share2 size={20} />
-              </button>
-            </div>
-          </div>
-        </div>
-      );
-    });
+    feedContent = confessionFeed.map((item) => (
+      <ConfessionFeedCard
+        key={String(item?._id || item?.id || "")}
+        item={item}
+        currentUserId={currentUserId}
+        expandedConfessionIds={expandedConfessionIds}
+        menuConfessionId={menuConfessionId}
+        gestureLikeBurstId={gestureLikeBurstId}
+        pressedLikeId={pressedLikeId}
+        pressedBookmarkId={pressedBookmarkId}
+        onToggleConfessionMenu={handleToggleConfessionMenu}
+        onEditConfession={handleEditConfession}
+        onDeleteConfession={handleDeleteConfession}
+        onToggleExpandedConfession={handleToggleExpandedConfession}
+        onToggleLike={handleToggleLike}
+        onOpenCommentModal={openCommentModal}
+        onToggleBookmark={handleToggleBookmark}
+      />
+    ));
   }
 
   return (
@@ -902,18 +699,6 @@ export default function Confession() {
         <main className="flex-1 min-h-0 overflow-hidden">
           <div className="h-full overflow-y-auto pt-6 sm:pt-8 lg:pt-10 px-3 sm:px-5 lg:px-6 pb-8 sm:pb-10 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
             <div className="max-w-4xl mx-auto flex flex-col items-center justify-start">
-              {errorMessage && (
-                <div className="w-full mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
-                  {errorMessage}
-                </div>
-              )}
-
-              {successMessage && (
-                <div className="w-full mb-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
-                  {successMessage}
-                </div>
-              )}
-
               <div className="bg-slate-900 text-white p-8 rounded-3xl sm:rounded-[40px] text-left relative overflow-hidden w-full shadow-sm">
                 <div className="absolute top-0 right-0 w-32 h-32 bg-rose-500/20 blur-3xl"></div>
                 <div className="relative z-10">
@@ -1032,48 +817,55 @@ export default function Confession() {
                 {!isLoadingModalComments &&
                   !modalCommentsError &&
                   modalComments.map((comment) => {
-                    const commentId = String(
-                      comment?._id || comment?.id || "comment",
-                    );
-                    const commentAuthor =
-                      comment?.authorDisplayName || "Anonymous";
-                    const commentAvatarSrc =
-                      comment?.authorProfilePicture ||
-                      `https://api.dicebear.com/7.x/bottts/svg?seed=${encodeURIComponent(
-                        commentAuthor,
-                      )}`;
-
                     return (
-                      <div
-                        key={commentId}
-                        className="rounded-xl border border-slate-100 bg-slate-50 px-3 py-2"
-                      >
-                        <div className="mb-2 flex items-start gap-3">
-                          <div className="h-8 w-8 overflow-hidden rounded-full bg-slate-200 shrink-0">
-                            <img
-                              src={commentAvatarSrc}
-                              alt="commenter avatar"
-                              className="h-full w-full object-cover"
-                            />
-                          </div>
-
-                          <div className="min-w-0 flex-1">
-                            <div className="flex items-center justify-between gap-3">
-                              <span className="text-xs font-semibold text-slate-700 truncate">
-                                {commentAuthor}
-                              </span>
-                              <span className="text-[11px] text-slate-400 shrink-0">
-                                {getRelativeTime(comment?.createdAt)}
-                              </span>
-                            </div>
-                            <p className="text-sm text-slate-700 whitespace-pre-wrap mt-1">
-                              {comment?.content || "No comment content"}
-                            </p>
-                          </div>
-                        </div>
-                      </div>
+                      <ConfessionModalCommentItem
+                        key={String(comment?._id || comment?.id || "comment")}
+                        comment={comment}
+                        currentUserId={currentUserId}
+                        activeCommentMenuId={activeCommentMenuId}
+                        editingCommentId={editingCommentId}
+                        editCommentContent={editCommentContent}
+                        isSavingEditedComment={isSavingEditedComment}
+                        deleteTargetCommentId={deleteTargetCommentId}
+                        isDeletingComment={isDeletingComment}
+                        onToggleMenu={handleToggleCommentMenu}
+                        onStartEdit={handleStartEditComment}
+                        onDelete={handleDeleteComment}
+                        onCancelEdit={handleCancelEditComment}
+                        onEditContentChange={setEditCommentContent}
+                        onSaveEdit={handleSaveEditedComment}
+                        onCancelDelete={() => setDeleteTargetCommentId("")}
+                        onConfirmDelete={handleConfirmDeleteComment}
+                      />
                     );
                   })}
+              </div>
+
+              <div className="border-t border-slate-100 px-4 py-3">
+                <div className="flex items-end gap-2">
+                  <textarea
+                    value={newCommentContent}
+                    onChange={(event) =>
+                      setNewCommentContent(event.target.value)
+                    }
+                    className="flex-1 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-sm text-slate-800 outline-none focus:border-rose-300 resize-none"
+                    rows={2}
+                    placeholder="Write a comment..."
+                  />
+                  <button
+                    type="button"
+                    onClick={handleAddComment}
+                    disabled={isSubmittingComment}
+                    className="inline-flex items-center justify-center gap-1.5 rounded-xl bg-rose-500 px-3 py-2 text-xs font-semibold text-white hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60"
+                  >
+                    {isSubmittingComment ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : (
+                      <SendHorizontal className="h-3.5 w-3.5" />
+                    )}
+                    {isSubmittingComment ? "Posting..." : "Post"}
+                  </button>
+                </div>
               </div>
             </div>
           </div>
@@ -1213,6 +1005,77 @@ export default function Confession() {
           </div>
         )}
       </div>
+
+      {toast && (
+        <div className="pointer-events-none fixed right-4 top-4 z-90 w-[min(92vw,360px)]">
+          <div
+            className={`pointer-events-auto rounded-2xl border bg-white/95 shadow-2xl backdrop-blur px-4 py-3 transition-all duration-200 ease-out ${
+              isToastVisible
+                ? "translate-x-0 opacity-100"
+                : "translate-x-8 opacity-0"
+            } ${
+              {
+                success: "border-emerald-200",
+                error: "border-rose-200",
+              }[toast.type]
+            }`}
+            role="status"
+            aria-live="polite"
+          >
+            <div className="flex items-start gap-3">
+              <div
+                className={`mt-0.5 shrink-0 ${
+                  toast.type === "success"
+                    ? "text-emerald-600"
+                    : "text-rose-600"
+                }`}
+              >
+                {toast.type === "success" ? (
+                  <CheckCircle2 size={18} />
+                ) : (
+                  <AlertCircle size={18} />
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="text-[13px] font-semibold text-slate-900">
+                  {toast.type === "success" ? "Done" : "Alert"}
+                </p>
+                <p className="mt-0.5 text-sm leading-snug text-slate-600 wrap-break-word">
+                  {toast.message}
+                </p>
+              </div>
+              <button
+                type="button"
+                onClick={dismissToast}
+                className="shrink-0 rounded-full p-1 text-slate-400 hover:bg-slate-100 hover:text-slate-700 transition-colors"
+                aria-label="Dismiss notification"
+              >
+                <X size={14} />
+              </button>
+            </div>
+            <div className="mt-3 h-1 overflow-hidden rounded-full bg-slate-100">
+              <div
+                key={toast.id}
+                className={`h-full origin-left ${
+                  toast.type === "success"
+                    ? "bg-emerald-500/70"
+                    : "bg-rose-500/70"
+                }`}
+                style={{
+                  animation: `toastCountDown ${TOAST_DURATION_MS}ms linear forwards`,
+                }}
+              />
+            </div>
+          </div>
+        </div>
+      )}
+
+      <style>{`
+        @keyframes toastCountDown {
+          from { transform: scaleX(1); }
+          to { transform: scaleX(0); }
+        }
+      `}</style>
     </div>
   );
 }

--- a/frontend/src/pages/Confession.jsx
+++ b/frontend/src/pages/Confession.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from "react";
+import React, { useState, useRef } from "react";
 
 import Sidebar from "../components/Sidebar";
 import Navbar from "../components/Navbar";
@@ -8,11 +8,85 @@ import {
   LockOpen,
   Eye,
   EyeOff,
+  Heart,
+  MessageCircle,
+  Bookmark,
+  Share2,
   Loader2,
   SendHorizontal,
 } from "lucide-react";
 
 const parseResponse = async (response) => response.json().catch(() => ({}));
+
+const formatCount = (value) => {
+  if (value >= 1000000) {
+    return `${(value / 1000000).toFixed(1).replace(/\.0$/, "")}M`;
+  }
+
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(1).replace(/\.0$/, "")}K`;
+  }
+
+  return String(value);
+};
+
+const RELATIVE_TIME_STEPS = [
+  { limitMinutes: 1, toLabel: () => "Just now" },
+  {
+    limitMinutes: 60,
+    toLabel: (minutes) => `${minutes} minute${minutes > 1 ? "s" : ""} ago`,
+  },
+  {
+    limitMinutes: 24 * 60,
+    toLabel: (minutes) => {
+      const hours = Math.floor(minutes / 60);
+      return `${hours} hour${hours > 1 ? "s" : ""} ago`;
+    },
+  },
+  {
+    limitMinutes: 7 * 24 * 60,
+    toLabel: (minutes) => {
+      const days = Math.floor(minutes / (24 * 60));
+      return `${days} day${days > 1 ? "s" : ""} ago`;
+    },
+  },
+  {
+    limitMinutes: 5 * 7 * 24 * 60,
+    toLabel: (minutes) => {
+      const weeks = Math.floor(minutes / (7 * 24 * 60));
+      return `${weeks} week${weeks > 1 ? "s" : ""} ago`;
+    },
+  },
+  {
+    limitMinutes: 12 * 30 * 24 * 60,
+    toLabel: (minutes) => {
+      const months = Math.floor(minutes / (30 * 24 * 60));
+      return `${months} month${months > 1 ? "s" : ""} ago`;
+    },
+  },
+];
+
+const getRelativeTime = (dateString) => {
+  const sourceDate = new Date(dateString);
+
+  if (Number.isNaN(sourceDate.getTime())) {
+    return "Recently";
+  }
+
+  const diffMs = Date.now() - sourceDate.getTime();
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+
+  for (const step of RELATIVE_TIME_STEPS) {
+    if (diffMinutes < step.limitMinutes) {
+      return step.toLabel(diffMinutes);
+    }
+  }
+
+  const diffYears = Math.floor(diffMinutes / (365 * 24 * 60));
+  return `${diffYears} year${diffYears > 1 ? "s" : ""} ago`;
+};
+
+const CONFESSION_FEED_LIMIT = 8;
 
 const extractTagsFromContent = (content) => {
   const matches = content.match(/#\w+/g) || [];
@@ -46,9 +120,60 @@ export default function Confession() {
   const [confession, setConfession] = useState("");
   const [isAnonymous, setIsAnonymous] = useState(true);
   const [visibility, setVisibility] = useState("public");
+  const [confessionFeed, setConfessionFeed] = useState([]);
+  const [nextCursor, setNextCursor] = useState("");
+  const [hasMoreFeed, setHasMoreFeed] = useState(false);
+  const [isLoadingFeed, setIsLoadingFeed] = useState(true);
+  const [isLoadingMoreFeed, setIsLoadingMoreFeed] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [errorMessage, setErrorMessage] = useState("");
   const [successMessage, setSuccessMessage] = useState("");
+  const [pressedLikeId, setPressedLikeId] = useState(null);
+  const [pressedBookmarkId, setPressedBookmarkId] = useState(null);
+  const [gestureLikeBurstId, setGestureLikeBurstId] = useState(null);
+  const sentinelRef = useRef(null);
+  const lastTapRef = useRef({ confessionId: "", time: 0 });
+
+  const loadConfessions = async ({ cursor = "", append = false } = {}) => {
+    if (append) {
+      setIsLoadingMoreFeed(true);
+    } else {
+      setIsLoadingFeed(true);
+    }
+
+    try {
+      const params = new URLSearchParams({
+        limit: String(CONFESSION_FEED_LIMIT),
+      });
+
+      if (cursor) {
+        params.set("cursor", cursor);
+      }
+
+      const token = localStorage.getItem("token");
+      const headers = token ? { Authorization: `Bearer ${token}` } : {};
+
+      const response = await fetch(`/api/confessions?${params.toString()}`, {
+        headers,
+      });
+      const payload = await parseResponse(response);
+
+      if (!response.ok) {
+        throw new Error(payload?.message || "Failed to load confessions.");
+      }
+
+      const data = Array.isArray(payload?.data) ? payload.data : [];
+
+      setConfessionFeed((prev) => (append ? [...prev, ...data] : data));
+      setNextCursor(payload?.nextCursor || "");
+      setHasMoreFeed(Boolean(payload?.hasMore));
+    } catch (error) {
+      setErrorMessage(error.message || "Failed to load confessions.");
+    } finally {
+      setIsLoadingFeed(false);
+      setIsLoadingMoreFeed(false);
+    }
+  };
 
   const handleSubmit = async () => {
     setErrorMessage("");
@@ -94,12 +219,358 @@ export default function Confession() {
 
       setConfession("");
       setSuccessMessage("Confession posted successfully.");
+      await loadConfessions();
     } catch (error) {
       setErrorMessage(error.message || "Failed to post confession.");
     } finally {
       setIsSubmitting(false);
     }
   };
+
+  const handleToggleLike = React.useCallback(async (confessionId) => {
+    const token = localStorage.getItem("token");
+    if (!token) {
+      setErrorMessage("Please log in to like confessions.");
+      return;
+    }
+
+    setPressedLikeId(confessionId);
+    setTimeout(() => {
+      setPressedLikeId((currentId) =>
+        currentId === confessionId ? null : currentId,
+      );
+    }, 150);
+
+    try {
+      const response = await fetch(
+        `/api/confessions/${confessionId}/toggle-like`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to toggle like.");
+      }
+
+      const payload = await parseResponse(response);
+
+      setConfessionFeed((prev) =>
+        prev.map((item) =>
+          item._id === confessionId || item.id === confessionId
+            ? {
+                ...item,
+                likedByCurrentUser: Boolean(payload.likedByCurrentUser),
+                likesCount: Number(payload.likesCount || 0),
+              }
+            : item,
+        ),
+      );
+    } catch (error) {
+      setErrorMessage(error.message || "Failed to toggle like.");
+    }
+  }, []);
+
+  const handleToggleBookmark = async (confessionId) => {
+    const token = localStorage.getItem("token");
+    if (!token) {
+      setErrorMessage("Please log in to bookmark confessions.");
+      return;
+    }
+
+    setPressedBookmarkId(confessionId);
+    setTimeout(() => {
+      setPressedBookmarkId((currentId) =>
+        currentId === confessionId ? null : currentId,
+      );
+    }, 150);
+
+    try {
+      const response = await fetch(
+        `/api/confessions/${confessionId}/toggle-bookmark`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+
+      if (!response.ok) {
+        throw new Error("Failed to toggle bookmark.");
+      }
+
+      const payload = await parseResponse(response);
+
+      setConfessionFeed((prev) =>
+        prev.map((item) =>
+          item._id === confessionId || item.id === confessionId
+            ? {
+                ...item,
+                savedByCurrentUser: Boolean(payload.savedByCurrentUser),
+              }
+            : item,
+        ),
+      );
+    } catch (error) {
+      setErrorMessage(error.message || "Failed to toggle bookmark.");
+    }
+  };
+
+  const handleCardLikeGesture = React.useCallback(
+    (confessionId, likedByCurrentUser) => {
+      if (likedByCurrentUser) {
+        return;
+      }
+
+      setGestureLikeBurstId(confessionId);
+      setTimeout(() => {
+        setGestureLikeBurstId((currentId) =>
+          currentId === confessionId ? null : currentId,
+        );
+      }, 450);
+
+      handleToggleLike(confessionId);
+    },
+    [handleToggleLike],
+  );
+
+  React.useEffect(() => {
+    const getCardMeta = (eventTarget) => {
+      if (!(eventTarget instanceof Element) || eventTarget.closest("button")) {
+        return null;
+      }
+
+      const card = eventTarget.closest("[data-confession-card-id]");
+      if (!card) {
+        return null;
+      }
+
+      const confessionId = card.dataset.confessionCardId;
+      const likedByCurrentUser = card.dataset.likedByCurrentUser === "true";
+
+      if (!confessionId) {
+        return null;
+      }
+
+      return {
+        confessionId,
+        likedByCurrentUser,
+      };
+    };
+
+    const handleDocumentDoubleClick = (event) => {
+      const cardMeta = getCardMeta(event.target);
+      if (!cardMeta) {
+        return;
+      }
+
+      handleCardLikeGesture(cardMeta.confessionId, cardMeta.likedByCurrentUser);
+    };
+
+    const handleDocumentTouchEnd = (event) => {
+      const cardMeta = getCardMeta(event.target);
+      if (!cardMeta) {
+        return;
+      }
+
+      const now = Date.now();
+      const lastTap = lastTapRef.current;
+
+      if (
+        lastTap.confessionId === cardMeta.confessionId &&
+        now - lastTap.time < 300
+      ) {
+        lastTapRef.current = { confessionId: "", time: 0 };
+        handleCardLikeGesture(
+          cardMeta.confessionId,
+          cardMeta.likedByCurrentUser,
+        );
+        return;
+      }
+
+      lastTapRef.current = {
+        confessionId: cardMeta.confessionId,
+        time: now,
+      };
+    };
+
+    document.addEventListener("dblclick", handleDocumentDoubleClick);
+    document.addEventListener("touchend", handleDocumentTouchEnd);
+
+    return () => {
+      document.removeEventListener("dblclick", handleDocumentDoubleClick);
+      document.removeEventListener("touchend", handleDocumentTouchEnd);
+    };
+  }, [handleCardLikeGesture]);
+
+  React.useEffect(() => {
+    void loadConfessions();
+  }, []);
+
+  React.useEffect(() => {
+    const observer = new IntersectionObserver(
+      (entries) => {
+        if (
+          entries[0].isIntersecting &&
+          hasMoreFeed &&
+          !isLoadingMoreFeed &&
+          !isLoadingFeed
+        ) {
+          void loadConfessions({ cursor: nextCursor, append: true });
+        }
+      },
+      { threshold: 0.1 },
+    );
+
+    const currentSentinel = sentinelRef.current;
+
+    if (currentSentinel) {
+      observer.observe(currentSentinel);
+    }
+
+    return () => {
+      if (currentSentinel) {
+        observer.unobserve(currentSentinel);
+      }
+    };
+  }, [hasMoreFeed, nextCursor, isLoadingMoreFeed, isLoadingFeed]);
+
+  let feedContent = null;
+
+  if (isLoadingFeed) {
+    feedContent = (
+      <div className="bg-white rounded-2xl sm:rounded-3xl p-5 sm:p-6 border border-slate-200 shadow-sm text-sm text-slate-500">
+        Loading confessions...
+      </div>
+    );
+  } else if (confessionFeed.length === 0) {
+    feedContent = (
+      <div className="bg-white rounded-2xl sm:rounded-3xl p-5 sm:p-6 border border-slate-200 shadow-sm text-sm text-slate-500">
+        No confessions yet. Be the first one to post.
+      </div>
+    );
+  } else {
+    feedContent = confessionFeed.map((item) => {
+      const originalAuthor = item?.authorDisplayName || "Unknown Author";
+      const author = item?.isAnonymous ? "Anonymous" : originalAuthor;
+      const authorSeed = String(author || "author");
+      const tags =
+        Array.isArray(item?.tags) && item.tags.length > 0 ? item.tags : [];
+      const confessionId = String(item?._id || item?.id || authorSeed);
+
+      return (
+        <div
+          key={confessionId}
+          data-confession-card-id={confessionId}
+          data-liked-by-current-user={Boolean(item?.likedByCurrentUser)}
+          className="relative bg-white rounded-2xl sm:rounded-3xl p-5 sm:p-6 mb-5 sm:mb-6 border border-slate-200 shadow-sm transition-all duration-300 hover:shadow-md"
+        >
+          {gestureLikeBurstId === confessionId && (
+            <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
+              <Heart
+                size={56}
+                className="text-rose-500/90 animate-pulse"
+                fill="currentColor"
+              />
+            </div>
+          )}
+
+          <div className="flex justify-between items-start mb-4">
+            <div className="flex items-center gap-3 min-w-0">
+              <div className="w-10 h-10 rounded-full bg-slate-200 overflow-hidden">
+                <img
+                  src={`https://api.dicebear.com/7.x/bottts/svg?seed=${encodeURIComponent(authorSeed)}`}
+                  alt="avatar"
+                />
+              </div>
+
+              <div className="min-w-0">
+                <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
+                  <h3 className="font-semibold text-slate-900 truncate">
+                    {author}
+                  </h3>
+                  <span className="text-slate-400 text-xs">
+                    • {getRelativeTime(item?.createdAt)}
+                  </span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <p className="text-slate-600 text-sm leading-relaxed mb-6 whitespace-pre-wrap">
+            {item?.content || "No confession content"}
+          </p>
+
+          {tags.length > 0 && (
+            <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1">
+              {tags.slice(0, 4).map((tag) => (
+                <button
+                  key={`${confessionId}-${tag}`}
+                  type="button"
+                  className="text-xs font-semibold tracking-wide text-rose-600 hover:underline cursor-pointer"
+                >
+                  #{tag}
+                </button>
+              ))}
+            </div>
+          )}
+
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 pt-4 border-t border-slate-100">
+            <div className="flex flex-wrap items-center gap-4 sm:gap-6">
+              <div className="relative">
+                <button
+                  onClick={() => handleToggleLike(confessionId)}
+                  className={`flex items-center gap-2 transition-all duration-200 cursor-pointer ${
+                    item?.likedByCurrentUser
+                      ? "text-rose-500"
+                      : "text-slate-500 hover:text-rose-500"
+                  } ${pressedLikeId === confessionId ? "scale-95" : "scale-100"}`}
+                >
+                  <Heart
+                    size={20}
+                    fill={item?.likedByCurrentUser ? "currentColor" : "none"}
+                  />
+                  <span className="text-xs sm:text-sm font-medium">
+                    {formatCount(Number(item?.likesCount || 0))}
+                  </span>
+                </button>
+              </div>
+
+              <button className="flex items-center gap-2 text-slate-500 transition-all duration-200 hover:text-sky-500 cursor-pointer">
+                <MessageCircle size={20} />
+                <span className="text-xs sm:text-sm font-medium">
+                  {formatCount(Number(item?.commentCount || 0))}
+                </span>
+              </button>
+            </div>
+
+            <div className="flex items-center gap-4">
+              <button
+                onClick={() => handleToggleBookmark(confessionId)}
+                className={`transition-colors cursor-pointer ${
+                  item?.savedByCurrentUser
+                    ? "text-rose-500"
+                    : "text-slate-500 hover:text-rose-500"
+                } ${pressedBookmarkId === confessionId ? "scale-95" : "scale-100"}`}
+              >
+                <Bookmark
+                  size={20}
+                  fill={item?.savedByCurrentUser ? "currentColor" : "none"}
+                />
+              </button>
+              <button className="text-slate-500 hover:text-slate-900 transition-colors cursor-pointer">
+                <Share2 size={20} />
+              </button>
+            </div>
+          </div>
+        </div>
+      );
+    });
+  }
 
   return (
     <div className="flex h-screen bg-slate-50 text-slate-900 overflow-hidden">
@@ -181,6 +652,24 @@ export default function Confession() {
                     </button>
                   </div>
                 </div>
+              </div>
+
+              <div className="mt-8 w-full">
+                <div className="mb-4 flex items-center justify-between">
+                  <h3 className="text-xl sm:text-2xl font-semibold text-slate-900">
+                    Confession Feed
+                  </h3>
+                </div>
+
+                {feedContent}
+
+                {isLoadingMoreFeed && (
+                  <div className="mt-4 flex justify-center">
+                    <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
+                  </div>
+                )}
+
+                <div ref={sentinelRef} className="h-10" />
               </div>
             </div>
             <SiteFooter />

--- a/frontend/src/pages/Confession.jsx
+++ b/frontend/src/pages/Confession.jsx
@@ -224,6 +224,7 @@ export default function Confession() {
   const [menuConfessionId, setMenuConfessionId] = useState("");
   const [expandedConfessionIds, setExpandedConfessionIds] = useState({});
   const [deleteTargetConfessionId, setDeleteTargetConfessionId] = useState("");
+  const [isDeletingConfession, setIsDeletingConfession] = useState(false);
   const sentinelRef = useRef(null);
   const lastTapRef = useRef({ confessionId: "", time: 0 });
   const pendingLikeIdsRef = useRef(new Set());
@@ -736,18 +737,19 @@ export default function Confession() {
   };
 
   const handleConfirmDeleteConfession = async () => {
-    if (!deleteTargetConfessionId) {
+    if (!deleteTargetConfessionId || isDeletingConfession) {
       return;
     }
 
     const confessionId = deleteTargetConfessionId;
-    setDeleteTargetConfessionId("");
-
     const token = localStorage.getItem("token");
     if (!token) {
       showError("Please log in again to delete a confession.");
       return;
     }
+
+    setIsDeletingConfession(true);
+    setDeleteTargetConfessionId("");
 
     try {
       const response = await fetch(`/api/confessions/${confessionId}`, {
@@ -776,6 +778,8 @@ export default function Confession() {
       showSuccess("Confession deleted successfully.");
     } catch (error) {
       showError(error.message || "Failed to delete confession.");
+    } finally {
+      setIsDeletingConfession(false);
     }
   };
 
@@ -1241,7 +1245,13 @@ export default function Confession() {
 
         <ModalDialog
           isOpen={Boolean(deleteTargetConfessionId)}
-          onClose={() => setDeleteTargetConfessionId("")}
+          onClose={() => {
+            if (isDeletingConfession) {
+              return;
+            }
+
+            setDeleteTargetConfessionId("");
+          }}
           title="Delete this confession?"
           titleId={deleteDialogTitleId}
           closeLabel="Close delete confession modal"
@@ -1256,16 +1266,18 @@ export default function Confession() {
               <button
                 type="button"
                 onClick={() => setDeleteTargetConfessionId("")}
-                className="px-4 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 cursor-pointer"
+                disabled={isDeletingConfession}
+                className="px-4 py-2 text-sm font-medium text-slate-600 hover:text-slate-800 disabled:cursor-not-allowed disabled:opacity-60 cursor-pointer"
               >
                 Cancel
               </button>
               <button
                 type="button"
                 onClick={handleConfirmDeleteConfession}
-                className="px-4 py-2 text-sm font-medium rounded-xl bg-rose-500 text-white hover:bg-rose-600 cursor-pointer"
+                disabled={isDeletingConfession}
+                className="px-4 py-2 text-sm font-medium rounded-xl bg-rose-500 text-white hover:bg-rose-600 disabled:cursor-not-allowed disabled:opacity-70 cursor-pointer"
               >
-                Delete
+                {isDeletingConfession ? "Deleting..." : "Delete"}
               </button>
             </div>
           </div>

--- a/frontend/src/pages/Confession.jsx
+++ b/frontend/src/pages/Confession.jsx
@@ -91,6 +91,7 @@ const getRelativeTime = (dateString) => {
 };
 
 const CONFESSION_FEED_LIMIT = 8;
+const CONFESSION_CONTENT_PREVIEW_LIMIT = 280;
 
 const extractTagsFromContent = (content) => {
   const matches = content.match(/#\w+/g) || [];
@@ -120,6 +121,23 @@ const stripTagsFromContent = (content) =>
     .replaceAll(/\n{3,}/g, "\n\n")
     .trim();
 
+const getConfessionContentPreview = (content, isExpanded) => {
+  const safeContent = content || "No confession content";
+  const isLongContent = safeContent.length > CONFESSION_CONTENT_PREVIEW_LIMIT;
+
+  if (!isLongContent || isExpanded) {
+    return {
+      visibleContent: safeContent,
+      isLongContent,
+    };
+  }
+
+  return {
+    visibleContent: `${safeContent.slice(0, CONFESSION_CONTENT_PREVIEW_LIMIT)}...`,
+    isLongContent,
+  };
+};
+
 export default function Confession() {
   const [confession, setConfession] = useState("");
   const [isAnonymous, setIsAnonymous] = useState(true);
@@ -142,6 +160,7 @@ export default function Confession() {
   const [editConfessionVisibility, setEditConfessionVisibility] =
     useState("public");
   const [menuConfessionId, setMenuConfessionId] = useState("");
+  const [expandedConfessionIds, setExpandedConfessionIds] = useState({});
   const [deleteTargetConfessionId, setDeleteTargetConfessionId] = useState("");
   const [activeCommentConfessionId, setActiveCommentConfessionId] =
     useState("");
@@ -415,6 +434,13 @@ export default function Confession() {
     );
   };
 
+  const handleToggleExpandedConfession = (confessionId) => {
+    setExpandedConfessionIds((prev) => ({
+      ...prev,
+      [confessionId]: !prev[confessionId],
+    }));
+  };
+
   const handleEditConfession = (item) => {
     const existingTags = Array.isArray(item?.tags) ? item.tags : [];
     const reconstructedEditContent = [
@@ -622,6 +648,31 @@ export default function Confession() {
   }, []);
 
   React.useEffect(() => {
+    if (!menuConfessionId) {
+      return undefined;
+    }
+
+    const handleClickOutsideMenu = (event) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest("[data-confession-menu]")
+      ) {
+        return;
+      }
+
+      setMenuConfessionId("");
+    };
+
+    document.addEventListener("mousedown", handleClickOutsideMenu);
+    document.addEventListener("touchstart", handleClickOutsideMenu);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutsideMenu);
+      document.removeEventListener("touchstart", handleClickOutsideMenu);
+    };
+  }, [menuConfessionId]);
+
+  React.useEffect(() => {
     const observer = new IntersectionObserver(
       (entries) => {
         if (
@@ -680,6 +731,11 @@ export default function Confession() {
       const confessionId = String(item?._id || item?.id || authorSeed);
       const canManageConfession =
         Boolean(currentUserId) && normalizeId(item?.authorId) === currentUserId;
+      const isExpanded = Boolean(expandedConfessionIds[confessionId]);
+      const { visibleContent, isLongContent } = getConfessionContentPreview(
+        item?.content,
+        isExpanded,
+      );
 
       return (
         <div
@@ -689,7 +745,7 @@ export default function Confession() {
           className="relative bg-white rounded-2xl sm:rounded-3xl p-5 sm:p-6 mb-5 sm:mb-6 border border-slate-200 shadow-sm transition-all duration-300 hover:shadow-md"
         >
           {canManageConfession && (
-            <div className="absolute right-4 top-4 z-20">
+            <div className="absolute right-4 top-4 z-20" data-confession-menu>
               <button
                 type="button"
                 onClick={() => handleToggleConfessionMenu(confessionId)}
@@ -750,9 +806,21 @@ export default function Confession() {
             </div>
           </div>
 
-          <p className="text-slate-600 text-sm leading-relaxed mb-6 whitespace-pre-wrap">
-            {item?.content || "No confession content"}
+          <p className="text-slate-600 text-sm leading-relaxed whitespace-pre-wrap">
+            {visibleContent}
           </p>
+
+          {isLongContent && (
+            <button
+              type="button"
+              onClick={() => handleToggleExpandedConfession(confessionId)}
+              className="mt-2 mb-6 text-xs font-semibold text-slate-500 hover:underline cursor-pointer"
+            >
+              {isExpanded ? "Show less" : "Show more"}
+            </button>
+          )}
+
+          {!isLongContent && <div className="mb-6" />}
 
           {tags.length > 0 && (
             <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1">
@@ -768,8 +836,8 @@ export default function Confession() {
             </div>
           )}
 
-          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 pt-4 border-t border-slate-100">
-            <div className="flex flex-wrap items-center gap-4 sm:gap-6">
+          <div className="flex items-center justify-between gap-3 pt-4 border-t border-slate-100">
+            <div className="flex items-center gap-3 min-w-0">
               <div className="relative">
                 <button
                   onClick={() => handleToggleLike(confessionId)}
@@ -800,7 +868,7 @@ export default function Confession() {
               </button>
             </div>
 
-            <div className="flex items-center gap-4">
+            <div className="flex items-center gap-3 shrink-0">
               <button
                 onClick={() => handleToggleBookmark(confessionId)}
                 className={`transition-colors cursor-pointer ${
@@ -846,17 +914,17 @@ export default function Confession() {
                 </div>
               )}
 
-              <div className="bg-slate-900 text-white sm:p-8 rounded-3xl sm:rounded-[40px] text-left relative overflow-hidden w-full shadow-sm">
+              <div className="bg-slate-900 text-white p-8 rounded-3xl sm:rounded-[40px] text-left relative overflow-hidden w-full shadow-sm">
                 <div className="absolute top-0 right-0 w-32 h-32 bg-rose-500/20 blur-3xl"></div>
                 <div className="relative z-10">
                   <div className="w-12 h-1 bg-rose-500 rounded-full mb-4"></div>
                   <textarea
                     value={confession}
                     onChange={(e) => setConfession(e.target.value)}
-                    className="bg-transparent border-none outline-none w-full h-36 sm:h-32 text-base lg:text-md sm:text-lg text-slate-200 resize-none placeholder:text-slate-400"
+                    className="bg-transparent border-none outline-none w-full h-32 text-base text-md text-slate-200 resize-none placeholder:text-slate-400"
                     placeholder="Write your confession..."
                   />
-                  <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-4 mt-4">
+                  <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-4 mt-2">
                     <div className="inline-flex items-center gap-2">
                       <button
                         type="button"
@@ -923,8 +991,15 @@ export default function Confession() {
         </main>
 
         {isCommentModalOpen && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4 py-6">
-            <div className="w-full max-w-xl rounded-2xl border border-slate-200 bg-white shadow-xl overflow-hidden">
+          <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
+            <button
+              type="button"
+              aria-label="Close comments modal"
+              onClick={closeCommentModal}
+              className="absolute inset-0 bg-slate-900/40"
+            />
+
+            <div className="relative z-10 w-full max-w-xl rounded-2xl border border-slate-200 bg-white shadow-xl overflow-hidden">
               <div className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
                 <h4 className="text-sm sm:text-base font-semibold text-slate-900 truncate pr-4">
                   Comments - {commentModalTitle}
@@ -1005,8 +1080,15 @@ export default function Confession() {
         )}
 
         {editingConfessionId && (
-          <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 backdrop-blur-[2px] px-4 py-6">
-            <div className="w-full max-w-2xl rounded-2xl border border-slate-200 bg-white shadow-xl overflow-hidden">
+          <div className="fixed inset-0 z-50 flex items-center justify-center px-4 py-6">
+            <button
+              type="button"
+              aria-label="Close edit confession modal"
+              onClick={handleCancelEditConfession}
+              className="absolute inset-0 bg-slate-900/40 backdrop-blur-[2px]"
+            />
+
+            <div className="relative z-10 w-full max-w-2xl rounded-2xl border border-slate-200 bg-white shadow-xl overflow-hidden">
               <div className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
                 <h4 className="text-sm sm:text-base font-semibold text-slate-900 truncate pr-4">
                   Edit Confession

--- a/frontend/src/pages/Confession.jsx
+++ b/frontend/src/pages/Confession.jsx
@@ -749,7 +749,6 @@ export default function Confession() {
     }
 
     setIsDeletingConfession(true);
-    setDeleteTargetConfessionId("");
 
     try {
       const response = await fetch(`/api/confessions/${confessionId}`, {
@@ -775,6 +774,7 @@ export default function Confession() {
         handleCancelEditConfession();
       }
 
+      setDeleteTargetConfessionId("");
       showSuccess("Confession deleted successfully.");
     } catch (error) {
       showError(error.message || "Failed to delete confession.");
@@ -975,10 +975,11 @@ export default function Confession() {
       </div>
     );
   } else {
-    feedContent = confessionFeed.map((item) => (
+    feedContent = confessionFeed.map((item, index) => (
       <ConfessionFeedCard
-        key={String(item?._id || item?.id || "")}
+        key={String(item?._id || item?.id || `feed-${index}`)}
         item={item}
+        index={index}
         currentUserId={currentUserId}
         expandedConfessionIds={expandedConfessionIds}
         menuConfessionId={menuConfessionId}
@@ -1106,10 +1107,12 @@ export default function Confession() {
               )}
 
             {!modalCommentsError &&
-              modalComments.map((comment) => {
+              modalComments.map((comment, index) => {
                 return (
                   <ConfessionModalCommentItem
-                    key={String(comment?._id || comment?.id || "comment")}
+                    key={String(
+                      comment?._id || comment?.id || `comment-${index}`,
+                    )}
                     comment={comment}
                     currentUserId={currentUserId}
                     activeCommentMenuId={activeCommentMenuId}

--- a/frontend/src/pages/Confession.jsx
+++ b/frontend/src/pages/Confession.jsx
@@ -14,6 +14,7 @@ import {
   Share2,
   Loader2,
   SendHorizontal,
+  X,
 } from "lucide-react";
 
 const parseResponse = async (response) => response.json().catch(() => ({}));
@@ -131,6 +132,12 @@ export default function Confession() {
   const [pressedLikeId, setPressedLikeId] = useState(null);
   const [pressedBookmarkId, setPressedBookmarkId] = useState(null);
   const [gestureLikeBurstId, setGestureLikeBurstId] = useState(null);
+  const [activeCommentConfessionId, setActiveCommentConfessionId] =
+    useState("");
+  const [commentModalTitle, setCommentModalTitle] = useState("");
+  const [modalComments, setModalComments] = useState([]);
+  const [isLoadingModalComments, setIsLoadingModalComments] = useState(false);
+  const [modalCommentsError, setModalCommentsError] = useState("");
   const sentinelRef = useRef(null);
   const lastTapRef = useRef({ confessionId: "", time: 0 });
 
@@ -338,6 +345,43 @@ export default function Confession() {
     [handleToggleLike],
   );
 
+  const closeCommentModal = () => {
+    setActiveCommentConfessionId("");
+    setCommentModalTitle("");
+    setModalComments([]);
+    setModalCommentsError("");
+    setIsLoadingModalComments(false);
+  };
+
+  const openCommentModal = async (confessionId, authorName) => {
+    setActiveCommentConfessionId(confessionId);
+    setCommentModalTitle(authorName || "Confession");
+    setModalComments([]);
+    setModalCommentsError("");
+    setIsLoadingModalComments(true);
+
+    try {
+      const token = localStorage.getItem("token");
+      const headers = token ? { Authorization: `Bearer ${token}` } : {};
+      const response = await fetch(
+        `/api/confessions/${confessionId}/comments?limit=10`,
+        { headers },
+      );
+      const payload = await parseResponse(response);
+
+      if (!response.ok) {
+        throw new Error(payload?.message || "Failed to load comments.");
+      }
+
+      const comments = Array.isArray(payload?.comments) ? payload.comments : [];
+      setModalComments(comments);
+    } catch (error) {
+      setModalCommentsError(error.message || "Failed to load comments.");
+    } finally {
+      setIsLoadingModalComments(false);
+    }
+  };
+
   React.useEffect(() => {
     const getCardMeta = (eventTarget) => {
       if (!(eventTarget instanceof Element) || eventTarget.closest("button")) {
@@ -440,6 +484,7 @@ export default function Confession() {
   }, [hasMoreFeed, nextCursor, isLoadingMoreFeed, isLoadingFeed]);
 
   let feedContent = null;
+  const isCommentModalOpen = Boolean(activeCommentConfessionId);
 
   if (isLoadingFeed) {
     feedContent = (
@@ -458,6 +503,12 @@ export default function Confession() {
       const originalAuthor = item?.authorDisplayName || "Unknown Author";
       const author = item?.isAnonymous ? "Anonymous" : originalAuthor;
       const authorSeed = String(author || "author");
+      const avatarSrc =
+        !item?.isAnonymous && item?.authorProfilePicture
+          ? item.authorProfilePicture
+          : `https://api.dicebear.com/7.x/bottts/svg?seed=${encodeURIComponent(
+              authorSeed,
+            )}`;
       const tags =
         Array.isArray(item?.tags) && item.tags.length > 0 ? item.tags : [];
       const confessionId = String(item?._id || item?.id || authorSeed);
@@ -482,10 +533,7 @@ export default function Confession() {
           <div className="flex justify-between items-start mb-4">
             <div className="flex items-center gap-3 min-w-0">
               <div className="w-10 h-10 rounded-full bg-slate-200 overflow-hidden">
-                <img
-                  src={`https://api.dicebear.com/7.x/bottts/svg?seed=${encodeURIComponent(authorSeed)}`}
-                  alt="avatar"
-                />
+                <img src={avatarSrc} alt="avatar" />
               </div>
 
               <div className="min-w-0">
@@ -540,7 +588,10 @@ export default function Confession() {
                 </button>
               </div>
 
-              <button className="flex items-center gap-2 text-slate-500 transition-all duration-200 hover:text-sky-500 cursor-pointer">
+              <button
+                onClick={() => openCommentModal(confessionId, author)}
+                className="flex items-center gap-2 text-slate-500 transition-all duration-200 hover:text-sky-500 cursor-pointer"
+              >
                 <MessageCircle size={20} />
                 <span className="text-xs sm:text-sm font-medium">
                   {formatCount(Number(item?.commentCount || 0))}
@@ -675,6 +726,88 @@ export default function Confession() {
             <SiteFooter />
           </div>
         </main>
+
+        {isCommentModalOpen && (
+          <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 px-4 py-6">
+            <div className="w-full max-w-xl rounded-2xl border border-slate-200 bg-white shadow-xl overflow-hidden">
+              <div className="flex items-center justify-between border-b border-slate-100 px-4 py-3">
+                <h4 className="text-sm sm:text-base font-semibold text-slate-900 truncate pr-4">
+                  Comments - {commentModalTitle}
+                </h4>
+                <button
+                  type="button"
+                  onClick={closeCommentModal}
+                  className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-900 transition-colors cursor-pointer"
+                  aria-label="Close comments"
+                >
+                  <X size={18} />
+                </button>
+              </div>
+
+              <div className="max-h-[65vh] overflow-y-auto px-4 py-4 space-y-3">
+                {isLoadingModalComments && (
+                  <p className="text-sm text-slate-500">Loading comments...</p>
+                )}
+
+                {!isLoadingModalComments && modalCommentsError && (
+                  <p className="text-sm text-rose-600">{modalCommentsError}</p>
+                )}
+
+                {!isLoadingModalComments &&
+                  !modalCommentsError &&
+                  modalComments.length === 0 && (
+                    <p className="text-sm text-slate-500">No comments yet.</p>
+                  )}
+
+                {!isLoadingModalComments &&
+                  !modalCommentsError &&
+                  modalComments.map((comment) => {
+                    const commentId = String(
+                      comment?._id || comment?.id || "comment",
+                    );
+                    const commentAuthor =
+                      comment?.authorDisplayName || "Anonymous";
+                    const commentAvatarSrc =
+                      comment?.authorProfilePicture ||
+                      `https://api.dicebear.com/7.x/bottts/svg?seed=${encodeURIComponent(
+                        commentAuthor,
+                      )}`;
+
+                    return (
+                      <div
+                        key={commentId}
+                        className="rounded-xl border border-slate-100 bg-slate-50 px-3 py-2"
+                      >
+                        <div className="mb-2 flex items-start gap-3">
+                          <div className="h-8 w-8 overflow-hidden rounded-full bg-slate-200 shrink-0">
+                            <img
+                              src={commentAvatarSrc}
+                              alt="commenter avatar"
+                              className="h-full w-full object-cover"
+                            />
+                          </div>
+
+                          <div className="min-w-0 flex-1">
+                            <div className="flex items-center justify-between gap-3">
+                              <span className="text-xs font-semibold text-slate-700 truncate">
+                                {commentAuthor}
+                              </span>
+                              <span className="text-[11px] text-slate-400 shrink-0">
+                                {getRelativeTime(comment?.createdAt)}
+                              </span>
+                            </div>
+                            <p className="text-sm text-slate-700 whitespace-pre-wrap mt-1">
+                              {comment?.content || "No comment content"}
+                            </p>
+                          </div>
+                        </div>
+                      </div>
+                    );
+                  })}
+              </div>
+            </div>
+          </div>
+        )}
       </div>
     </div>
   );

--- a/frontend/src/pages/Confession.jsx
+++ b/frontend/src/pages/Confession.jsx
@@ -3,61 +3,181 @@ import React, { useState } from "react";
 import Sidebar from "../components/Sidebar";
 import Navbar from "../components/Navbar";
 import SiteFooter from "../components/SiteFooter";
-import { Shield, Lock } from "lucide-react";
+import {
+  Lock,
+  LockOpen,
+  Eye,
+  EyeOff,
+  Loader2,
+  SendHorizontal,
+} from "lucide-react";
+
+const parseResponse = async (response) => response.json().catch(() => ({}));
+
+const extractTagsFromContent = (content) => {
+  const matches = content.match(/#\w+/g) || [];
+  const uniqueByLowercase = new Map();
+
+  for (const rawTag of matches) {
+    const cleanedTag = rawTag.slice(1).trim();
+
+    if (!cleanedTag) {
+      continue;
+    }
+
+    const normalizedKey = cleanedTag.toLowerCase();
+
+    if (!uniqueByLowercase.has(normalizedKey)) {
+      uniqueByLowercase.set(normalizedKey, cleanedTag);
+    }
+  }
+
+  return Array.from(uniqueByLowercase.values());
+};
+
+const stripTagsFromContent = (content) =>
+  content
+    .replaceAll(/#\w+/g, "")
+    .replaceAll(/[ \t]{2,}/g, " ")
+    .replaceAll(/\n{3,}/g, "\n\n")
+    .trim();
 
 export default function Confession() {
   const [confession, setConfession] = useState("");
+  const [isAnonymous, setIsAnonymous] = useState(true);
+  const [visibility, setVisibility] = useState("public");
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
 
-  const handleSubmit = () => {
-    if (confession.trim()) {
-      // Handle confession submission
-      console.log("Confession posted:", confession);
+  const handleSubmit = async () => {
+    setErrorMessage("");
+    setSuccessMessage("");
+
+    const cleanedContent = stripTagsFromContent(confession);
+
+    if (cleanedContent.length < 5) {
+      setErrorMessage("Write at least 5 characters before posting.");
+      return;
+    }
+
+    const token = localStorage.getItem("token");
+    if (!token) {
+      setErrorMessage("Please log in again to post a confession.");
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const extractedTags = extractTagsFromContent(confession);
+
+      const response = await fetch("/api/confessions", {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({
+          content: cleanedContent,
+          isAnonymous,
+          visibility,
+          tags: extractedTags,
+        }),
+      });
+
+      const payload = await parseResponse(response);
+
+      if (!response.ok) {
+        throw new Error(payload?.message || "Failed to post confession.");
+      }
+
       setConfession("");
-      // Could navigate or show success message
+      setSuccessMessage("Confession posted successfully.");
+    } catch (error) {
+      setErrorMessage(error.message || "Failed to post confession.");
+    } finally {
+      setIsSubmitting(false);
     }
   };
 
   return (
     <div className="flex h-screen bg-slate-50 text-slate-900 overflow-hidden">
       <Sidebar />
+
       <div className="flex-1 flex flex-col min-w-0 bg-slate-50">
         <Navbar title="Confession Wall" />
+
         <main className="flex-1 min-h-0 overflow-hidden">
           <div className="h-full overflow-y-auto pt-6 sm:pt-8 lg:pt-10 px-3 sm:px-5 lg:px-6 pb-8 sm:pb-10 [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-            <div className="max-w-2xl mx-auto flex flex-col items-center justify-start">
-              <div className="w-20 h-20 bg-rose-50 text-rose-500 rounded-full flex items-center justify-center mx-auto mb-6">
-                <Shield className="w-10 h-10" />
-              </div>
-              <h2 className="text-2xl sm:text-3xl font-semibold mb-4 text-center text-slate-900">
-                Post Anonymously
-              </h2>
-              <p className="text-slate-500 mb-10 text-center">
-                Share your thoughts without revealing your identity. Everything
-                here is safe, secure, and encrypted.
-              </p>
+            <div className="max-w-4xl flex flex-col items-center justify-start">
+              {errorMessage && (
+                <div className="w-full mb-4 rounded-2xl border border-rose-200 bg-rose-50 px-4 py-3 text-sm text-rose-700">
+                  {errorMessage}
+                </div>
+              )}
 
-              <div className="bg-slate-900 text-white p-6 sm:p-10 lg:p-12 rounded-3xl sm:rounded-[40px] text-left relative overflow-hidden w-full shadow-sm">
+              {successMessage && (
+                <div className="w-full mb-4 rounded-2xl border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+                  {successMessage}
+                </div>
+              )}
+
+              <div className="bg-slate-900 text-white sm:p-8 rounded-3xl sm:rounded-[40px] text-left relative overflow-hidden w-full shadow-sm">
                 <div className="absolute top-0 right-0 w-32 h-32 bg-rose-500/20 blur-3xl"></div>
                 <div className="relative z-10">
                   <div className="w-12 h-1 bg-rose-500 rounded-full mb-4"></div>
-                  <h3 className="text-lg sm:text-xl font-semibold mb-6 sm:mb-8">
-                    Write your confession...
-                  </h3>
                   <textarea
                     value={confession}
                     onChange={(e) => setConfession(e.target.value)}
-                    className="bg-transparent border-none outline-none w-full h-36 sm:h-32 text-base sm:text-lg text-slate-300 resize-none placeholder:text-slate-600"
-                    placeholder="Type here in complete anonymity..."
+                    className="bg-transparent border-none outline-none w-full h-36 sm:h-32 text-base lg:text-md sm:text-lg text-slate-200 resize-none placeholder:text-slate-400"
+                    placeholder="Write your confession..."
                   />
-                  <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-4 mt-8">
-                    <p className="text-xs text-slate-500 flex items-center gap-2">
-                      <Lock className="w-3 h-3" /> Encrypted end-to-end
-                    </p>
+                  <div className="flex flex-col sm:flex-row justify-between sm:items-center gap-4 mt-4">
+                    <div className="inline-flex items-center gap-2">
+                      <button
+                        type="button"
+                        onClick={() => setIsAnonymous((prev) => !prev)}
+                        aria-pressed={isAnonymous}
+                        className="text-xs text-slate-400 inline-flex items-center gap-2 rounded-full border border-slate-700/60 px-3 py-1.5 cursor-pointer hover:border-slate-500 hover:text-slate-200 transition-colors"
+                      >
+                        {isAnonymous ? (
+                          <Lock className="w-3.5 h-3.5" />
+                        ) : (
+                          <LockOpen className="w-3.5 h-3.5" />
+                        )}
+                        {isAnonymous ? "Anonymous" : "Identified"}
+                      </button>
+
+                      <button
+                        type="button"
+                        onClick={() =>
+                          setVisibility((prev) =>
+                            prev === "public" ? "private" : "public",
+                          )
+                        }
+                        aria-pressed={visibility === "private"}
+                        className="text-xs text-slate-400 inline-flex items-center gap-2 rounded-full border border-slate-700/60 px-3 py-1.5 cursor-pointer hover:border-slate-500 hover:text-slate-200 transition-colors"
+                      >
+                        {visibility === "public" ? (
+                          <Eye className="w-3.5 h-3.5" />
+                        ) : (
+                          <EyeOff className="w-3.5 h-3.5" />
+                        )}
+                        {visibility === "public" ? "Public" : "Private"}
+                      </button>
+                    </div>
                     <button
                       onClick={handleSubmit}
-                      className="w-full sm:w-auto px-8 py-2 bg-rose-500 text-white font-semibold rounded-full hover:bg-rose-600 transition-colors"
+                      disabled={isSubmitting}
+                      className="w-full sm:w-auto px-8 py-2 bg-rose-500 text-white font-semibold rounded-full hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60 disabled:cursor-not-allowed inline-flex items-center justify-center gap-2"
                     >
-                      Post Anonymously
+                      {isSubmitting ? (
+                        <Loader2 className="h-4 w-4 animate-spin" />
+                      ) : (
+                        <SendHorizontal className="h-4 w-4" />
+                      )}
+                      {isSubmitting ? "Posting..." : "Post"}
                     </button>
                   </div>
                 </div>

--- a/frontend/src/pages/confession/ConfessionFeedCard.jsx
+++ b/frontend/src/pages/confession/ConfessionFeedCard.jsx
@@ -1,4 +1,3 @@
-import PropTypes from "prop-types";
 import {
   Heart,
   MessageCircle,
@@ -14,14 +13,55 @@ import {
   normalizeId,
 } from "./confessionUtils";
 
+/**
+ * @typedef {Object} ConfessionFeedItem
+ * @property {string | object} [_id]
+ * @property {string | object} [id]
+ * @property {string | object} [authorId]
+ * @property {string} [authorDisplayName]
+ * @property {string} [authorProfilePicture]
+ * @property {boolean} [isAnonymous]
+ * @property {string[]} [tags]
+ * @property {string} [content]
+ * @property {string} [createdAt]
+ * @property {boolean} [isEdited]
+ * @property {boolean} [likedByCurrentUser]
+ * @property {boolean} [savedByCurrentUser]
+ * @property {number} [likesCount]
+ * @property {number} [commentCount]
+ */
+
+/**
+ * @typedef {Object} ConfessionFeedCardProps
+ * @property {ConfessionFeedItem} item
+ * @property {string} [currentUserId]
+ * @property {Record<string, boolean>} [expandedConfessionIds]
+ * @property {string} [menuConfessionId]
+ * @property {string | null} [gestureLikeBurstId]
+ * @property {string | null} [pressedLikeId]
+ * @property {string | null} [pressedBookmarkId]
+ * @property {(confessionId: string) => void} onToggleConfessionMenu
+ * @property {(item: ConfessionFeedItem) => void} onEditConfession
+ * @property {(confessionId: string) => void} onDeleteConfession
+ * @property {(confessionId: string) => void} onToggleExpandedConfession
+ * @property {(confessionId: string) => void} onToggleLike
+ * @property {(confessionId: string, author: string) => void} onOpenCommentModal
+ * @property {(confessionId: string) => void} onToggleBookmark
+ * @property {(payload: { tag: string, confessionId: string, item: ConfessionFeedItem }) => void} [onTagClick]
+ * @property {(payload: { confessionId: string, item: ConfessionFeedItem, shareUrl: string, method: string }) => void | Promise<void>} [onShare]
+ */
+
+/**
+ * @param {ConfessionFeedCardProps} props
+ */
 export default function ConfessionFeedCard({
   item,
-  currentUserId,
-  expandedConfessionIds,
-  menuConfessionId,
-  gestureLikeBurstId,
-  pressedLikeId,
-  pressedBookmarkId,
+  currentUserId = "",
+  expandedConfessionIds = {},
+  menuConfessionId = "",
+  gestureLikeBurstId = null,
+  pressedLikeId = null,
+  pressedBookmarkId = null,
   onToggleConfessionMenu,
   onEditConfession,
   onDeleteConfession,
@@ -29,6 +69,8 @@ export default function ConfessionFeedCard({
   onToggleLike,
   onOpenCommentModal,
   onToggleBookmark,
+  onTagClick,
+  onShare,
 }) {
   const originalAuthor = item?.authorDisplayName || "Unknown Author";
   const author = item?.isAnonymous ? "Anonymous" : originalAuthor;
@@ -49,10 +91,77 @@ export default function ConfessionFeedCard({
     item?.content,
     isExpanded,
   );
+  const shareUrl =
+    typeof window === "undefined"
+      ? ""
+      : `${window.location.origin}${window.location.pathname}#confession-${confessionId}`;
+
+  const handleShare = async () => {
+    const shareTitle =
+      author === "Anonymous" ? "Confession" : `${author}'s confession`;
+    const shareText = (item?.content || "Read this confession on Story Hub.")
+      .slice(0, 160)
+      .trim();
+
+    const emitShare = async (method) => {
+      if (typeof onShare === "function") {
+        await onShare({
+          confessionId,
+          item,
+          shareUrl,
+          method,
+        });
+      }
+    };
+
+    try {
+      if (
+        typeof navigator !== "undefined" &&
+        typeof navigator.share === "function"
+      ) {
+        await navigator.share({
+          title: shareTitle,
+          text: shareText,
+          url: shareUrl,
+        });
+        await emitShare("web-share");
+        return;
+      }
+
+      if (
+        typeof navigator !== "undefined" &&
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === "function"
+      ) {
+        await navigator.clipboard.writeText(shareUrl);
+        await emitShare("clipboard");
+        return;
+      }
+    } catch {
+      if (
+        typeof navigator !== "undefined" &&
+        navigator.clipboard &&
+        typeof navigator.clipboard.writeText === "function"
+      ) {
+        await navigator.clipboard.writeText(shareUrl);
+        await emitShare("clipboard");
+        return;
+      }
+    }
+
+    if (typeof window !== "undefined") {
+      window.open(
+        `mailto:?subject=${encodeURIComponent(shareTitle)}&body=${encodeURIComponent(
+          `${shareText}\n\n${shareUrl}`,
+        )}`,
+        "_self",
+      );
+      await emitShare("mailto");
+    }
+  };
 
   return (
     <div
-      key={confessionId}
       data-confession-card-id={confessionId}
       data-liked-by-current-user={Boolean(item?.likedByCurrentUser)}
       className="relative bg-white rounded-2xl sm:rounded-3xl p-5 sm:p-6 mb-5 sm:mb-6 border border-slate-200 shadow-sm transition-all duration-300 hover:shadow-md"
@@ -141,6 +250,7 @@ export default function ConfessionFeedCard({
             <button
               key={`${confessionId}-${tag}`}
               type="button"
+              onClick={() => onTagClick?.({ tag, confessionId, item })}
               className="text-xs font-semibold tracking-wide text-rose-600 hover:underline cursor-pointer"
             >
               #{tag}
@@ -153,6 +263,7 @@ export default function ConfessionFeedCard({
         <div className="flex items-center gap-6 min-w-0">
           <div className="relative">
             <button
+              type="button"
               onClick={() => onToggleLike(confessionId)}
               className={`flex items-center gap-2 transition-all duration-200 cursor-pointer ${
                 item?.likedByCurrentUser
@@ -171,6 +282,7 @@ export default function ConfessionFeedCard({
           </div>
 
           <button
+            type="button"
             onClick={() => onOpenCommentModal(confessionId, author)}
             className="flex items-center gap-2 text-slate-500 transition-all duration-200 hover:text-sky-500 cursor-pointer"
           >
@@ -183,6 +295,7 @@ export default function ConfessionFeedCard({
 
         <div className="flex items-center gap-6 shrink-0">
           <button
+            type="button"
             onClick={() => onToggleBookmark(confessionId)}
             className={`transition-colors cursor-pointer ${
               item?.savedByCurrentUser
@@ -195,7 +308,12 @@ export default function ConfessionFeedCard({
               fill={item?.savedByCurrentUser ? "currentColor" : "none"}
             />
           </button>
-          <button className="text-slate-500 hover:text-slate-900 transition-colors cursor-pointer">
+          <button
+            type="button"
+            onClick={handleShare}
+            className="text-slate-500 hover:text-slate-900 transition-colors cursor-pointer"
+            aria-label="Share confession"
+          >
             <Share2 size={20} />
           </button>
         </div>
@@ -203,29 +321,3 @@ export default function ConfessionFeedCard({
     </div>
   );
 }
-
-ConfessionFeedCard.propTypes = {
-  item: PropTypes.object.isRequired,
-  currentUserId: PropTypes.string,
-  expandedConfessionIds: PropTypes.object,
-  menuConfessionId: PropTypes.string,
-  gestureLikeBurstId: PropTypes.string,
-  pressedLikeId: PropTypes.string,
-  pressedBookmarkId: PropTypes.string,
-  onToggleConfessionMenu: PropTypes.func.isRequired,
-  onEditConfession: PropTypes.func.isRequired,
-  onDeleteConfession: PropTypes.func.isRequired,
-  onToggleExpandedConfession: PropTypes.func.isRequired,
-  onToggleLike: PropTypes.func.isRequired,
-  onOpenCommentModal: PropTypes.func.isRequired,
-  onToggleBookmark: PropTypes.func.isRequired,
-};
-
-ConfessionFeedCard.defaultProps = {
-  currentUserId: "",
-  expandedConfessionIds: {},
-  menuConfessionId: "",
-  gestureLikeBurstId: null,
-  pressedLikeId: null,
-  pressedBookmarkId: null,
-};

--- a/frontend/src/pages/confession/ConfessionFeedCard.jsx
+++ b/frontend/src/pages/confession/ConfessionFeedCard.jsx
@@ -40,6 +40,7 @@ import {
  * @property {string | null} [gestureLikeBurstId]
  * @property {string | null} [pressedLikeId]
  * @property {string | null} [pressedBookmarkId]
+ * @property {number} [index]
  * @property {(confessionId: string) => void} onToggleConfessionMenu
  * @property {(item: ConfessionFeedItem) => void} onEditConfession
  * @property {(confessionId: string) => void} onDeleteConfession
@@ -62,6 +63,7 @@ export default function ConfessionFeedCard({
   gestureLikeBurstId = null,
   pressedLikeId = null,
   pressedBookmarkId = null,
+  index = 0,
   onToggleConfessionMenu,
   onEditConfession,
   onDeleteConfession,
@@ -83,7 +85,7 @@ export default function ConfessionFeedCard({
         )}`;
   const tags =
     Array.isArray(item?.tags) && item.tags.length > 0 ? item.tags : [];
-  const confessionId = String(item?._id || item?.id || authorSeed);
+  const confessionId = String(item?._id || item?.id || `fallback-${index}`);
   const canManageConfession =
     Boolean(currentUserId) && normalizeId(item?.authorId) === currentUserId;
   const isExpanded = Boolean(expandedConfessionIds[confessionId]);

--- a/frontend/src/pages/confession/ConfessionFeedCard.jsx
+++ b/frontend/src/pages/confession/ConfessionFeedCard.jsx
@@ -1,0 +1,231 @@
+import PropTypes from "prop-types";
+import {
+  Heart,
+  MessageCircle,
+  Bookmark,
+  Share2,
+  MoreHorizontal,
+} from "lucide-react";
+
+import {
+  formatCount,
+  getRelativeTime,
+  getConfessionContentPreview,
+  normalizeId,
+} from "./confessionUtils";
+
+export default function ConfessionFeedCard({
+  item,
+  currentUserId,
+  expandedConfessionIds,
+  menuConfessionId,
+  gestureLikeBurstId,
+  pressedLikeId,
+  pressedBookmarkId,
+  onToggleConfessionMenu,
+  onEditConfession,
+  onDeleteConfession,
+  onToggleExpandedConfession,
+  onToggleLike,
+  onOpenCommentModal,
+  onToggleBookmark,
+}) {
+  const originalAuthor = item?.authorDisplayName || "Unknown Author";
+  const author = item?.isAnonymous ? "Anonymous" : originalAuthor;
+  const authorSeed = String(author || "author");
+  const avatarSrc =
+    !item?.isAnonymous && item?.authorProfilePicture
+      ? item.authorProfilePicture
+      : `https://api.dicebear.com/7.x/bottts/svg?seed=${encodeURIComponent(
+          authorSeed,
+        )}`;
+  const tags =
+    Array.isArray(item?.tags) && item.tags.length > 0 ? item.tags : [];
+  const confessionId = String(item?._id || item?.id || authorSeed);
+  const canManageConfession =
+    Boolean(currentUserId) && normalizeId(item?.authorId) === currentUserId;
+  const isExpanded = Boolean(expandedConfessionIds[confessionId]);
+  const { visibleContent, isLongContent } = getConfessionContentPreview(
+    item?.content,
+    isExpanded,
+  );
+
+  return (
+    <div
+      key={confessionId}
+      data-confession-card-id={confessionId}
+      data-liked-by-current-user={Boolean(item?.likedByCurrentUser)}
+      className="relative bg-white rounded-2xl sm:rounded-3xl p-5 sm:p-6 mb-5 sm:mb-6 border border-slate-200 shadow-sm transition-all duration-300 hover:shadow-md"
+    >
+      {canManageConfession && (
+        <div className="absolute right-4 top-4 z-20" data-confession-menu>
+          <button
+            type="button"
+            onClick={() => onToggleConfessionMenu(confessionId)}
+            className="inline-flex h-8 w-8 items-center justify-center rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-900 transition-colors cursor-pointer"
+            aria-label="Confession actions"
+          >
+            <MoreHorizontal size={18} />
+          </button>
+
+          {menuConfessionId === confessionId && (
+            <div className="absolute right-0 top-10 w-28 rounded-xl border border-slate-200 bg-white shadow-lg py-1 overflow-hidden">
+              <button
+                type="button"
+                onClick={() => onEditConfession(item)}
+                className="w-full px-3 py-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-50"
+              >
+                Edit
+              </button>
+              <button
+                type="button"
+                onClick={() => onDeleteConfession(confessionId)}
+                className="w-full px-3 py-2 text-left text-xs font-medium text-rose-600 hover:bg-rose-50"
+              >
+                Delete
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
+      {gestureLikeBurstId === confessionId && (
+        <div className="pointer-events-none absolute inset-0 z-10 flex items-center justify-center">
+          <Heart
+            size={56}
+            className="text-rose-500/90 animate-pulse"
+            fill="currentColor"
+          />
+        </div>
+      )}
+
+      <div className="flex justify-between items-start mb-4">
+        <div className="flex items-center gap-3 min-w-0">
+          <div className="w-10 h-10 rounded-full bg-slate-200 overflow-hidden">
+            <img src={avatarSrc} alt="avatar" />
+          </div>
+
+          <div className="min-w-0">
+            <div className="flex flex-col sm:flex-row sm:items-center gap-1 sm:gap-2">
+              <h3 className="font-semibold text-slate-900 truncate">
+                {author}
+              </h3>
+              <div className="flex items-center gap-1 text-xs text-slate-400">
+                <span>• {getRelativeTime(item?.createdAt)}</span>
+                {item?.isEdited && <span>• Edited</span>}
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <p className="text-slate-600 text-sm leading-relaxed whitespace-pre-wrap">
+        {visibleContent}
+      </p>
+
+      {isLongContent && (
+        <button
+          type="button"
+          onClick={() => onToggleExpandedConfession(confessionId)}
+          className="mt-2 mb-6 text-xs font-semibold text-slate-500 hover:underline cursor-pointer"
+        >
+          {isExpanded ? "Show less" : "Show more"}
+        </button>
+      )}
+
+      {!isLongContent && <div className="mb-6" />}
+
+      {tags.length > 0 && (
+        <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1">
+          {tags.slice(0, 4).map((tag) => (
+            <button
+              key={`${confessionId}-${tag}`}
+              type="button"
+              className="text-xs font-semibold tracking-wide text-rose-600 hover:underline cursor-pointer"
+            >
+              #{tag}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div className="flex items-center justify-between gap-3 pt-4 border-t border-slate-100">
+        <div className="flex items-center gap-6 min-w-0">
+          <div className="relative">
+            <button
+              onClick={() => onToggleLike(confessionId)}
+              className={`flex items-center gap-2 transition-all duration-200 cursor-pointer ${
+                item?.likedByCurrentUser
+                  ? "text-rose-500"
+                  : "text-slate-500 hover:text-rose-500"
+              } ${pressedLikeId === confessionId ? "scale-95" : "scale-100"}`}
+            >
+              <Heart
+                size={20}
+                fill={item?.likedByCurrentUser ? "currentColor" : "none"}
+              />
+              <span className="text-xs sm:text-sm font-medium">
+                {formatCount(Number(item?.likesCount || 0))}
+              </span>
+            </button>
+          </div>
+
+          <button
+            onClick={() => onOpenCommentModal(confessionId, author)}
+            className="flex items-center gap-2 text-slate-500 transition-all duration-200 hover:text-sky-500 cursor-pointer"
+          >
+            <MessageCircle size={20} />
+            <span className="text-xs sm:text-sm font-medium">
+              {formatCount(Number(item?.commentCount || 0))}
+            </span>
+          </button>
+        </div>
+
+        <div className="flex items-center gap-6 shrink-0">
+          <button
+            onClick={() => onToggleBookmark(confessionId)}
+            className={`transition-colors cursor-pointer ${
+              item?.savedByCurrentUser
+                ? "text-rose-500"
+                : "text-slate-500 hover:text-rose-500"
+            } ${pressedBookmarkId === confessionId ? "scale-95" : "scale-100"}`}
+          >
+            <Bookmark
+              size={20}
+              fill={item?.savedByCurrentUser ? "currentColor" : "none"}
+            />
+          </button>
+          <button className="text-slate-500 hover:text-slate-900 transition-colors cursor-pointer">
+            <Share2 size={20} />
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ConfessionFeedCard.propTypes = {
+  item: PropTypes.object.isRequired,
+  currentUserId: PropTypes.string,
+  expandedConfessionIds: PropTypes.object,
+  menuConfessionId: PropTypes.string,
+  gestureLikeBurstId: PropTypes.string,
+  pressedLikeId: PropTypes.string,
+  pressedBookmarkId: PropTypes.string,
+  onToggleConfessionMenu: PropTypes.func.isRequired,
+  onEditConfession: PropTypes.func.isRequired,
+  onDeleteConfession: PropTypes.func.isRequired,
+  onToggleExpandedConfession: PropTypes.func.isRequired,
+  onToggleLike: PropTypes.func.isRequired,
+  onOpenCommentModal: PropTypes.func.isRequired,
+  onToggleBookmark: PropTypes.func.isRequired,
+};
+
+ConfessionFeedCard.defaultProps = {
+  currentUserId: "",
+  expandedConfessionIds: {},
+  menuConfessionId: "",
+  gestureLikeBurstId: null,
+  pressedLikeId: null,
+  pressedBookmarkId: null,
+};

--- a/frontend/src/pages/confession/ConfessionModalCommentItem.jsx
+++ b/frontend/src/pages/confession/ConfessionModalCommentItem.jsx
@@ -55,6 +55,10 @@ export default function ConfessionModalCommentItem({
   onCancelDelete,
   onConfirmDelete,
 }) {
+  if (!comment) {
+    return null;
+  }
+
   const commentId = String(comment?._id || comment?.id || "comment");
   const commentAuthor = comment?.authorDisplayName || "Anonymous";
   const canManageComment =
@@ -157,31 +161,34 @@ export default function ConfessionModalCommentItem({
             </p>
           )}
 
-          {deleteTargetCommentId === commentId && (
-            <div className="mt-2 rounded-lg border border-rose-100 bg-rose-50 px-3 py-2">
-              <p className="text-xs text-rose-700 mb-2">Delete this comment?</p>
-              <div className="flex items-center justify-end gap-2">
-                <button
-                  type="button"
-                  onClick={onCancelDelete}
-                  className="px-2.5 py-1 text-xs font-medium text-slate-600 hover:text-slate-800 cursor-pointer"
-                >
-                  Cancel
-                </button>
-                <button
-                  type="button"
-                  onClick={onConfirmDelete}
-                  disabled={isDeletingComment}
-                  className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-rose-500 px-2.5 py-1 text-xs font-semibold text-white hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60"
-                >
-                  {isDeletingComment ? (
-                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
-                  ) : null}
-                  {isDeletingComment ? "Deleting..." : "Delete"}
-                </button>
+          {deleteTargetCommentId === commentId &&
+            editingCommentId !== commentId && (
+              <div className="mt-2 rounded-lg border border-rose-100 bg-rose-50 px-3 py-2">
+                <p className="text-xs text-rose-700 mb-2">
+                  Delete this comment?
+                </p>
+                <div className="flex items-center justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={onCancelDelete}
+                    className="px-2.5 py-1 text-xs font-medium text-slate-600 hover:text-slate-800 cursor-pointer"
+                  >
+                    Cancel
+                  </button>
+                  <button
+                    type="button"
+                    onClick={onConfirmDelete}
+                    disabled={isDeletingComment}
+                    className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-rose-500 px-2.5 py-1 text-xs font-semibold text-white hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60"
+                  >
+                    {isDeletingComment ? (
+                      <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                    ) : null}
+                    {isDeletingComment ? "Deleting..." : "Delete"}
+                  </button>
+                </div>
               </div>
-            </div>
-          )}
+            )}
         </div>
       </div>
     </div>

--- a/frontend/src/pages/confession/ConfessionModalCommentItem.jsx
+++ b/frontend/src/pages/confession/ConfessionModalCommentItem.jsx
@@ -29,7 +29,7 @@ import { getRelativeTime, normalizeId } from "./confessionUtils";
  * @property {(commentId: string) => void} onDelete
  * @property {() => void} onCancelEdit
  * @property {(value: string) => void} onEditContentChange
- * @property {(commentId: string) => void} onSaveEdit
+ * @property {() => void} onSaveEdit
  * @property {() => void} onCancelDelete
  * @property {() => void} onConfirmDelete
  */
@@ -140,7 +140,7 @@ export default function ConfessionModalCommentItem({
                 </button>
                 <button
                   type="button"
-                  onClick={() => onSaveEdit(commentId)}
+                  onClick={onSaveEdit}
                   disabled={isSavingEditedComment}
                   className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-rose-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60"
                 >

--- a/frontend/src/pages/confession/ConfessionModalCommentItem.jsx
+++ b/frontend/src/pages/confession/ConfessionModalCommentItem.jsx
@@ -1,17 +1,51 @@
-import PropTypes from "prop-types";
 import { Loader2, MoreHorizontal } from "lucide-react";
 
 import { getRelativeTime, normalizeId } from "./confessionUtils";
 
+/**
+ * @typedef {Object} ConfessionComment
+ * @property {string | object} [_id]
+ * @property {string | object} [id]
+ * @property {string | object} [userId]
+ * @property {string} [authorDisplayName]
+ * @property {string} [authorProfilePicture]
+ * @property {string} [createdAt]
+ * @property {string} [content]
+ * @property {boolean} [isEdited]
+ */
+
+/**
+ * @typedef {Object} ConfessionModalCommentItemProps
+ * @property {ConfessionComment | null} [comment]
+ * @property {string} [currentUserId]
+ * @property {string} [activeCommentMenuId]
+ * @property {string} [editingCommentId]
+ * @property {string} [editCommentContent]
+ * @property {boolean} [isSavingEditedComment]
+ * @property {string} [deleteTargetCommentId]
+ * @property {boolean} [isDeletingComment]
+ * @property {(commentId: string) => void} onToggleMenu
+ * @property {(comment: ConfessionComment | null) => void} onStartEdit
+ * @property {(commentId: string) => void} onDelete
+ * @property {() => void} onCancelEdit
+ * @property {(value: string) => void} onEditContentChange
+ * @property {(commentId: string) => void} onSaveEdit
+ * @property {() => void} onCancelDelete
+ * @property {() => void} onConfirmDelete
+ */
+
+/**
+ * @param {ConfessionModalCommentItemProps} props
+ */
 export default function ConfessionModalCommentItem({
-  comment,
-  currentUserId,
-  activeCommentMenuId,
-  editingCommentId,
-  editCommentContent,
-  isSavingEditedComment,
-  deleteTargetCommentId,
-  isDeletingComment,
+  comment = null,
+  currentUserId = "",
+  activeCommentMenuId = "",
+  editingCommentId = "",
+  editCommentContent = "",
+  isSavingEditedComment = false,
+  deleteTargetCommentId = "",
+  isDeletingComment = false,
   onToggleMenu,
   onStartEdit,
   onDelete,
@@ -153,42 +187,3 @@ export default function ConfessionModalCommentItem({
     </div>
   );
 }
-
-ConfessionModalCommentItem.propTypes = {
-  comment: PropTypes.shape({
-    _id: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-    id: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-    userId: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
-    authorDisplayName: PropTypes.string,
-    authorProfilePicture: PropTypes.string,
-    createdAt: PropTypes.string,
-    content: PropTypes.string,
-    isEdited: PropTypes.bool,
-  }),
-  currentUserId: PropTypes.string,
-  activeCommentMenuId: PropTypes.string,
-  editingCommentId: PropTypes.string,
-  editCommentContent: PropTypes.string,
-  isSavingEditedComment: PropTypes.bool,
-  deleteTargetCommentId: PropTypes.string,
-  isDeletingComment: PropTypes.bool,
-  onToggleMenu: PropTypes.func.isRequired,
-  onStartEdit: PropTypes.func.isRequired,
-  onDelete: PropTypes.func.isRequired,
-  onCancelEdit: PropTypes.func.isRequired,
-  onEditContentChange: PropTypes.func.isRequired,
-  onSaveEdit: PropTypes.func.isRequired,
-  onCancelDelete: PropTypes.func.isRequired,
-  onConfirmDelete: PropTypes.func.isRequired,
-};
-
-ConfessionModalCommentItem.defaultProps = {
-  comment: null,
-  currentUserId: "",
-  activeCommentMenuId: "",
-  editingCommentId: "",
-  editCommentContent: "",
-  isSavingEditedComment: false,
-  deleteTargetCommentId: "",
-  isDeletingComment: false,
-};

--- a/frontend/src/pages/confession/ConfessionModalCommentItem.jsx
+++ b/frontend/src/pages/confession/ConfessionModalCommentItem.jsx
@@ -1,0 +1,194 @@
+import PropTypes from "prop-types";
+import { Loader2, MoreHorizontal } from "lucide-react";
+
+import { getRelativeTime, normalizeId } from "./confessionUtils";
+
+export default function ConfessionModalCommentItem({
+  comment,
+  currentUserId,
+  activeCommentMenuId,
+  editingCommentId,
+  editCommentContent,
+  isSavingEditedComment,
+  deleteTargetCommentId,
+  isDeletingComment,
+  onToggleMenu,
+  onStartEdit,
+  onDelete,
+  onCancelEdit,
+  onEditContentChange,
+  onSaveEdit,
+  onCancelDelete,
+  onConfirmDelete,
+}) {
+  const commentId = String(comment?._id || comment?.id || "comment");
+  const commentAuthor = comment?.authorDisplayName || "Anonymous";
+  const canManageComment =
+    Boolean(currentUserId) && normalizeId(comment?.userId) === currentUserId;
+  const commentAvatarSrc =
+    comment?.authorProfilePicture ||
+    `https://api.dicebear.com/7.x/bottts/svg?seed=${encodeURIComponent(
+      commentAuthor,
+    )}`;
+
+  return (
+    <div className="rounded-xl border border-slate-100 bg-slate-50 px-3 py-2">
+      <div className="mb-2 flex items-start gap-3">
+        <div className="h-8 w-8 overflow-hidden rounded-full bg-slate-200 shrink-0">
+          <img
+            src={commentAvatarSrc}
+            alt="commenter avatar"
+            className="h-full w-full object-cover"
+          />
+        </div>
+
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center justify-between gap-3">
+            <div className="min-w-0">
+              <span className="text-xs font-semibold text-slate-700 truncate block">
+                {commentAuthor}
+              </span>
+              <span className="text-[11px] text-slate-400 shrink-0 inline-flex items-center gap-1">
+                <span>{getRelativeTime(comment?.createdAt)}</span>
+                {comment?.isEdited ? <span>• Edited</span> : null}
+              </span>
+            </div>
+
+            {canManageComment ? (
+              <div className="relative" data-comment-menu>
+                <button
+                  type="button"
+                  onClick={() => onToggleMenu(commentId)}
+                  className="inline-flex h-7 w-7 items-center justify-center rounded-full text-slate-500 hover:bg-slate-100 hover:text-slate-900 transition-colors cursor-pointer"
+                  aria-label="Comment actions"
+                >
+                  <MoreHorizontal size={16} />
+                </button>
+
+                {activeCommentMenuId === commentId && (
+                  <div className="absolute right-0 top-8 w-28 rounded-xl border border-slate-200 bg-white shadow-lg py-1 overflow-hidden z-10">
+                    <button
+                      type="button"
+                      onClick={() => onStartEdit(comment)}
+                      className="w-full px-3 py-2 text-left text-xs font-medium text-slate-700 hover:bg-slate-50"
+                    >
+                      Edit
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDelete(commentId)}
+                      className="w-full px-3 py-2 text-left text-xs font-medium text-rose-600 hover:bg-rose-50"
+                    >
+                      Delete
+                    </button>
+                  </div>
+                )}
+              </div>
+            ) : null}
+          </div>
+
+          {editingCommentId === commentId ? (
+            <div className="mt-2 space-y-2">
+              <textarea
+                value={editCommentContent}
+                onChange={(event) => onEditContentChange(event.target.value)}
+                className="w-full rounded-xl border border-slate-200 bg-white px-3 py-2 text-sm text-slate-800 outline-none focus:border-rose-300 resize-none"
+                rows={3}
+                placeholder="Edit your comment..."
+              />
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={onCancelEdit}
+                  className="px-3 py-1.5 text-xs font-medium text-slate-600 hover:text-slate-800 cursor-pointer"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={() => onSaveEdit(commentId)}
+                  disabled={isSavingEditedComment}
+                  className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-rose-500 px-3 py-1.5 text-xs font-semibold text-white hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60"
+                >
+                  {isSavingEditedComment ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : null}
+                  {isSavingEditedComment ? "Saving..." : "Save"}
+                </button>
+              </div>
+            </div>
+          ) : (
+            <p className="text-sm text-slate-700 whitespace-pre-wrap mt-1">
+              {comment?.content || "No comment content"}
+            </p>
+          )}
+
+          {deleteTargetCommentId === commentId && (
+            <div className="mt-2 rounded-lg border border-rose-100 bg-rose-50 px-3 py-2">
+              <p className="text-xs text-rose-700 mb-2">Delete this comment?</p>
+              <div className="flex items-center justify-end gap-2">
+                <button
+                  type="button"
+                  onClick={onCancelDelete}
+                  className="px-2.5 py-1 text-xs font-medium text-slate-600 hover:text-slate-800 cursor-pointer"
+                >
+                  Cancel
+                </button>
+                <button
+                  type="button"
+                  onClick={onConfirmDelete}
+                  disabled={isDeletingComment}
+                  className="inline-flex items-center justify-center gap-1.5 rounded-lg bg-rose-500 px-2.5 py-1 text-xs font-semibold text-white hover:bg-rose-600 transition-colors cursor-pointer disabled:opacity-60"
+                >
+                  {isDeletingComment ? (
+                    <Loader2 className="h-3.5 w-3.5 animate-spin" />
+                  ) : null}
+                  {isDeletingComment ? "Deleting..." : "Delete"}
+                </button>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+ConfessionModalCommentItem.propTypes = {
+  comment: PropTypes.shape({
+    _id: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    id: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    userId: PropTypes.oneOfType([PropTypes.string, PropTypes.object]),
+    authorDisplayName: PropTypes.string,
+    authorProfilePicture: PropTypes.string,
+    createdAt: PropTypes.string,
+    content: PropTypes.string,
+    isEdited: PropTypes.bool,
+  }),
+  currentUserId: PropTypes.string,
+  activeCommentMenuId: PropTypes.string,
+  editingCommentId: PropTypes.string,
+  editCommentContent: PropTypes.string,
+  isSavingEditedComment: PropTypes.bool,
+  deleteTargetCommentId: PropTypes.string,
+  isDeletingComment: PropTypes.bool,
+  onToggleMenu: PropTypes.func.isRequired,
+  onStartEdit: PropTypes.func.isRequired,
+  onDelete: PropTypes.func.isRequired,
+  onCancelEdit: PropTypes.func.isRequired,
+  onEditContentChange: PropTypes.func.isRequired,
+  onSaveEdit: PropTypes.func.isRequired,
+  onCancelDelete: PropTypes.func.isRequired,
+  onConfirmDelete: PropTypes.func.isRequired,
+};
+
+ConfessionModalCommentItem.defaultProps = {
+  comment: null,
+  currentUserId: "",
+  activeCommentMenuId: "",
+  editingCommentId: "",
+  editCommentContent: "",
+  isSavingEditedComment: false,
+  deleteTargetCommentId: "",
+  isDeletingComment: false,
+};

--- a/frontend/src/pages/confession/confessionUtils.js
+++ b/frontend/src/pages/confession/confessionUtils.js
@@ -61,6 +61,10 @@ export const getRelativeTime = (dateString) => {
   const diffMs = Date.now() - sourceDate.getTime();
   const diffMinutes = Math.floor(diffMs / (1000 * 60));
 
+  if (diffMinutes < 0) {
+    return "Recently";
+  }
+
   for (const step of RELATIVE_TIME_STEPS) {
     if (diffMinutes < step.limitMinutes) {
       return step.toLabel(diffMinutes);

--- a/frontend/src/pages/confession/confessionUtils.js
+++ b/frontend/src/pages/confession/confessionUtils.js
@@ -1,0 +1,120 @@
+export const normalizeId = (value) => String(value || "").trim();
+
+export const parseResponse = async (response) =>
+  response.json().catch(() => ({}));
+
+export const formatCount = (value) => {
+  if (value >= 1000000) {
+    return `${(value / 1000000).toFixed(1).replace(/\.0$/, "")}M`;
+  }
+
+  if (value >= 1000) {
+    return `${(value / 1000).toFixed(1).replace(/\.0$/, "")}K`;
+  }
+
+  return String(value);
+};
+
+const RELATIVE_TIME_STEPS = [
+  { limitMinutes: 1, toLabel: () => "Just now" },
+  {
+    limitMinutes: 60,
+    toLabel: (minutes) => `${minutes} minute${minutes > 1 ? "s" : ""} ago`,
+  },
+  {
+    limitMinutes: 24 * 60,
+    toLabel: (minutes) => {
+      const hours = Math.floor(minutes / 60);
+      return `${hours} hour${hours > 1 ? "s" : ""} ago`;
+    },
+  },
+  {
+    limitMinutes: 7 * 24 * 60,
+    toLabel: (minutes) => {
+      const days = Math.floor(minutes / (24 * 60));
+      return `${days} day${days > 1 ? "s" : ""} ago`;
+    },
+  },
+  {
+    limitMinutes: 5 * 7 * 24 * 60,
+    toLabel: (minutes) => {
+      const weeks = Math.floor(minutes / (7 * 24 * 60));
+      return `${weeks} week${weeks > 1 ? "s" : ""} ago`;
+    },
+  },
+  {
+    limitMinutes: 12 * 30 * 24 * 60,
+    toLabel: (minutes) => {
+      const months = Math.floor(minutes / (30 * 24 * 60));
+      return `${months} month${months > 1 ? "s" : ""} ago`;
+    },
+  },
+];
+
+export const getRelativeTime = (dateString) => {
+  const sourceDate = new Date(dateString);
+
+  if (Number.isNaN(sourceDate.getTime())) {
+    return "Recently";
+  }
+
+  const diffMs = Date.now() - sourceDate.getTime();
+  const diffMinutes = Math.floor(diffMs / (1000 * 60));
+
+  for (const step of RELATIVE_TIME_STEPS) {
+    if (diffMinutes < step.limitMinutes) {
+      return step.toLabel(diffMinutes);
+    }
+  }
+
+  const diffYears = Math.floor(diffMinutes / (365 * 24 * 60));
+  return `${diffYears} year${diffYears > 1 ? "s" : ""} ago`;
+};
+
+export const CONFESSION_FEED_LIMIT = 8;
+export const CONFESSION_CONTENT_PREVIEW_LIMIT = 280;
+
+export const extractTagsFromContent = (content) => {
+  const matches = content.match(/#\w+/g) || [];
+  const uniqueByLowercase = new Map();
+
+  for (const rawTag of matches) {
+    const cleanedTag = rawTag.slice(1).trim();
+
+    if (!cleanedTag) {
+      continue;
+    }
+
+    const normalizedKey = cleanedTag.toLowerCase();
+
+    if (!uniqueByLowercase.has(normalizedKey)) {
+      uniqueByLowercase.set(normalizedKey, cleanedTag);
+    }
+  }
+
+  return Array.from(uniqueByLowercase.values());
+};
+
+export const stripTagsFromContent = (content) =>
+  content
+    .replaceAll(/#\w+/g, "")
+    .replaceAll(/[ \t]{2,}/g, " ")
+    .replaceAll(/\n{3,}/g, "\n\n")
+    .trim();
+
+export const getConfessionContentPreview = (content, isExpanded) => {
+  const safeContent = content || "No confession content";
+  const isLongContent = safeContent.length > CONFESSION_CONTENT_PREVIEW_LIMIT;
+
+  if (!isLongContent || isExpanded) {
+    return {
+      visibleContent: safeContent,
+      isLongContent,
+    };
+  }
+
+  return {
+    visibleContent: `${safeContent.slice(0, CONFESSION_CONTENT_PREVIEW_LIMIT)}...`,
+    isLongContent,
+  };
+};

--- a/frontend/src/pages/confession/confessionUtils.js
+++ b/frontend/src/pages/confession/confessionUtils.js
@@ -4,6 +4,10 @@ export const parseResponse = async (response) =>
   response.json().catch(() => ({}));
 
 export const formatCount = (value) => {
+  if (value == null || Number.isNaN(Number(value))) {
+    return "0";
+  }
+
   if (value >= 1000000) {
     return `${(value / 1000000).toFixed(1).replace(/\.0$/, "")}M`;
   }
@@ -43,7 +47,7 @@ const RELATIVE_TIME_STEPS = [
     },
   },
   {
-    limitMinutes: 12 * 30 * 24 * 60,
+    limitMinutes: 365 * 24 * 60,
     toLabel: (minutes) => {
       const months = Math.floor(minutes / (30 * 24 * 60));
       return `${months} month${months > 1 ? "s" : ""} ago`;
@@ -100,7 +104,7 @@ export const extractTagsFromContent = (content) => {
 };
 
 export const stripTagsFromContent = (content) =>
-  content
+  (content || "")
     .replaceAll(/#\w+/g, "")
     .replaceAll(/[ \t]{2,}/g, " ")
     .replaceAll(/\n{3,}/g, "\n\n")

--- a/frontend/src/pages/confession/useConfessionComments.js
+++ b/frontend/src/pages/confession/useConfessionComments.js
@@ -20,6 +20,9 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
   const [isLoadingModalComments, setIsLoadingModalComments] =
     React.useState(false);
   const [modalCommentsError, setModalCommentsError] = React.useState("");
+  const [modalCommentsNextCursor, setModalCommentsNextCursor] =
+    React.useState("");
+  const [modalCommentsHasMore, setModalCommentsHasMore] = React.useState(false);
 
   const updateConfessionCommentCount = React.useCallback(
     (confessionId, by) => {
@@ -41,36 +44,73 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
     [setConfessionFeed],
   );
 
-  const loadModalComments = React.useCallback(async (confessionId) => {
-    setModalCommentsError("");
-    setIsLoadingModalComments(true);
+  const loadModalComments = React.useCallback(
+    async (confessionId, cursor = "") => {
+      setModalCommentsError("");
+      setIsLoadingModalComments(true);
 
-    try {
-      const token = localStorage.getItem("token");
-      const headers = token ? { Authorization: `Bearer ${token}` } : {};
-      const response = await fetch(
-        `/api/confessions/${confessionId}/comments?limit=10`,
-        { headers },
-      );
-      const payload = await parseResponse(response);
+      try {
+        const token = localStorage.getItem("token");
+        const headers = token ? { Authorization: `Bearer ${token}` } : {};
+        const params = new URLSearchParams({ limit: "10" });
 
-      if (!response.ok) {
-        throw new Error(payload?.message || "Failed to load comments.");
+        if (cursor) {
+          params.set("cursor", cursor);
+        }
+
+        const response = await fetch(
+          `/api/confessions/${confessionId}/comments?${params.toString()}`,
+          { headers },
+        );
+        const payload = await parseResponse(response);
+
+        if (!response.ok) {
+          throw new Error(payload?.message || "Failed to load comments.");
+        }
+
+        const comments = Array.isArray(payload?.comments)
+          ? payload.comments
+          : [];
+        const nextCursor = payload?.nextCursor || "";
+        const hasMore = Boolean(payload?.hasMore);
+
+        setModalComments((prev) => [...prev, ...comments]);
+        setModalCommentsNextCursor(nextCursor);
+        setModalCommentsHasMore(hasMore);
+      } catch (error) {
+        setModalCommentsError(error.message || "Failed to load comments.");
+      } finally {
+        setIsLoadingModalComments(false);
       }
+    },
+    [],
+  );
 
-      const comments = Array.isArray(payload?.comments) ? payload.comments : [];
-      setModalComments(comments);
-    } catch (error) {
-      setModalCommentsError(error.message || "Failed to load comments.");
-    } finally {
-      setIsLoadingModalComments(false);
+  const loadMoreModalComments = React.useCallback(async () => {
+    if (
+      !activeCommentConfessionId ||
+      !modalCommentsHasMore ||
+      !modalCommentsNextCursor ||
+      isLoadingModalComments
+    ) {
+      return;
     }
-  }, []);
+
+    await loadModalComments(activeCommentConfessionId, modalCommentsNextCursor);
+  }, [
+    activeCommentConfessionId,
+    isLoadingModalComments,
+    loadModalComments,
+    modalCommentsHasMore,
+    modalCommentsNextCursor,
+  ]);
 
   const closeCommentModal = () => {
     setActiveCommentConfessionId("");
     setCommentModalTitle("");
     setModalComments([]);
+    setModalCommentsNextCursor("");
+    setModalCommentsHasMore(false);
     setNewCommentContent("");
     setActiveCommentMenuId("");
     setEditingCommentId("");
@@ -84,6 +124,8 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
     setActiveCommentConfessionId(confessionId);
     setCommentModalTitle(authorName || "Confession");
     setModalComments([]);
+    setModalCommentsNextCursor("");
+    setModalCommentsHasMore(false);
     setNewCommentContent("");
     setActiveCommentMenuId("");
     setEditingCommentId("");
@@ -132,6 +174,9 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
       }
 
       setNewCommentContent("");
+      setModalComments([]);
+      setModalCommentsNextCursor("");
+      setModalCommentsHasMore(false);
       await loadModalComments(activeCommentConfessionId);
       updateConfessionCommentCount(activeCommentConfessionId, 1);
     } catch (error) {
@@ -160,10 +205,16 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
     setEditCommentContent("");
   };
 
-  const handleSaveEditedComment = async (commentId) => {
+  const handleSaveEditedComment = async () => {
+    const targetCommentId = editingCommentId;
     const cleanedContent = editCommentContent.trim();
     const token = localStorage.getItem("token");
     const hasContent = cleanedContent.length > 0;
+
+    if (!targetCommentId) {
+      setModalCommentsError("No comment is selected for editing.");
+      return;
+    }
 
     if (!hasContent || !token) {
       setModalCommentsError(
@@ -178,33 +229,40 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
     setModalCommentsError("");
 
     try {
-      const response = await fetch(`/api/confessions/comments/${commentId}`, {
-        method: "PUT",
-        headers: {
-          "Content-Type": "application/json",
-          Authorization: `Bearer ${token}`,
+      const response = await fetch(
+        `/api/confessions/comments/${targetCommentId}`,
+        {
+          method: "PUT",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ content: cleanedContent }),
         },
-        body: JSON.stringify({ content: cleanedContent }),
-      });
+      );
       const payload = await parseResponse(response);
 
       if (!response.ok) {
         throw new Error(payload?.message || "Failed to edit comment.");
       }
 
+      const updatedComment = payload?.comment;
+
       setModalComments((prev) =>
         prev.map((comment) => {
           const currentId = String(comment?._id || comment?.id || "");
 
-          if (currentId !== commentId) {
+          if (currentId !== targetCommentId) {
+            return comment;
+          }
+
+          if (!updatedComment) {
             return comment;
           }
 
           return {
             ...comment,
-            content: cleanedContent,
-            isEdited: true,
-            updatedAt: new Date().toISOString(),
+            ...updatedComment,
           };
         }),
       );
@@ -257,13 +315,19 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
       }
 
       const deletedId = deleteTargetCommentId;
+      const removedCount = Number(payload?.removedCount);
+      const commentCountDelta =
+        Number.isFinite(removedCount) && removedCount > 0 ? -removedCount : -1;
       setDeleteTargetCommentId("");
       setModalComments((prev) =>
         prev.filter(
           (comment) => String(comment?._id || comment?.id || "") !== deletedId,
         ),
       );
-      updateConfessionCommentCount(activeCommentConfessionId, -1);
+      updateConfessionCommentCount(
+        activeCommentConfessionId,
+        commentCountDelta,
+      );
     } catch (error) {
       setModalCommentsError(error.message || "Failed to delete comment.");
     } finally {
@@ -298,8 +362,10 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
     isDeletingComment,
     isLoadingModalComments,
     modalCommentsError,
+    modalCommentsHasMore,
     closeCommentModal,
     openCommentModal,
+    loadMoreModalComments,
     handleAddComment,
     handleToggleCommentMenu,
     handleStartEditComment,

--- a/frontend/src/pages/confession/useConfessionComments.js
+++ b/frontend/src/pages/confession/useConfessionComments.js
@@ -106,10 +106,8 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
             : mergeCommentsById(prev, comments),
         );
 
-        if (!preservePagination) {
-          setModalCommentsNextCursor(nextCursor);
-          setModalCommentsHasMore(hasMore);
-        }
+        setModalCommentsNextCursor(nextCursor);
+        setModalCommentsHasMore(hasMore);
       } catch (error) {
         setModalCommentsError(error.message || "Failed to load comments.");
       } finally {
@@ -168,7 +166,7 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
   };
 
   const handleAddComment = async () => {
-    if (!activeCommentConfessionId) {
+    if (!activeCommentConfessionId || isSubmittingComment) {
       return;
     }
 
@@ -238,6 +236,9 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
   };
 
   const handleSaveEditedComment = async () => {
+    if (isSavingEditedComment) {
+      return;
+    }
     const targetCommentId = editingCommentId;
     const cleanedContent = editCommentContent.trim();
     const token = localStorage.getItem("token");
@@ -316,7 +317,11 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
   };
 
   const handleConfirmDeleteComment = async () => {
-    if (!deleteTargetCommentId || !activeCommentConfessionId) {
+    if (
+      !deleteTargetCommentId ||
+      !activeCommentConfessionId ||
+      isDeletingComment
+    ) {
       return;
     }
 

--- a/frontend/src/pages/confession/useConfessionComments.js
+++ b/frontend/src/pages/confession/useConfessionComments.js
@@ -271,9 +271,13 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
     }
   };
 
+  const closeCommentMenu = React.useCallback(() => {
+    setActiveCommentMenuId("");
+  }, []);
+
   useOutsideClickCloser(
     Boolean(activeCommentMenuId),
-    () => setActiveCommentMenuId(""),
+    closeCommentMenu,
     "[data-comment-menu]",
   );
 

--- a/frontend/src/pages/confession/useConfessionComments.js
+++ b/frontend/src/pages/confession/useConfessionComments.js
@@ -1,0 +1,307 @@
+import React from "react";
+
+import { parseResponse } from "./confessionUtils";
+import { useOutsideClickCloser } from "./useOutsideClickCloser";
+
+export const useConfessionComments = ({ setConfessionFeed }) => {
+  const [activeCommentConfessionId, setActiveCommentConfessionId] =
+    React.useState("");
+  const [commentModalTitle, setCommentModalTitle] = React.useState("");
+  const [modalComments, setModalComments] = React.useState([]);
+  const [newCommentContent, setNewCommentContent] = React.useState("");
+  const [isSubmittingComment, setIsSubmittingComment] = React.useState(false);
+  const [activeCommentMenuId, setActiveCommentMenuId] = React.useState("");
+  const [editingCommentId, setEditingCommentId] = React.useState("");
+  const [editCommentContent, setEditCommentContent] = React.useState("");
+  const [isSavingEditedComment, setIsSavingEditedComment] =
+    React.useState(false);
+  const [deleteTargetCommentId, setDeleteTargetCommentId] = React.useState("");
+  const [isDeletingComment, setIsDeletingComment] = React.useState(false);
+  const [isLoadingModalComments, setIsLoadingModalComments] =
+    React.useState(false);
+  const [modalCommentsError, setModalCommentsError] = React.useState("");
+
+  const updateConfessionCommentCount = React.useCallback(
+    (confessionId, by) => {
+      setConfessionFeed((prev) =>
+        prev.map((item) => {
+          const itemId = String(item?._id || item?.id || "");
+
+          if (itemId !== confessionId) {
+            return item;
+          }
+
+          return {
+            ...item,
+            commentCount: Math.max(0, Number(item?.commentCount || 0) + by),
+          };
+        }),
+      );
+    },
+    [setConfessionFeed],
+  );
+
+  const loadModalComments = React.useCallback(async (confessionId) => {
+    setModalCommentsError("");
+    setIsLoadingModalComments(true);
+
+    try {
+      const token = localStorage.getItem("token");
+      const headers = token ? { Authorization: `Bearer ${token}` } : {};
+      const response = await fetch(
+        `/api/confessions/${confessionId}/comments?limit=10`,
+        { headers },
+      );
+      const payload = await parseResponse(response);
+
+      if (!response.ok) {
+        throw new Error(payload?.message || "Failed to load comments.");
+      }
+
+      const comments = Array.isArray(payload?.comments) ? payload.comments : [];
+      setModalComments(comments);
+    } catch (error) {
+      setModalCommentsError(error.message || "Failed to load comments.");
+    } finally {
+      setIsLoadingModalComments(false);
+    }
+  }, []);
+
+  const closeCommentModal = () => {
+    setActiveCommentConfessionId("");
+    setCommentModalTitle("");
+    setModalComments([]);
+    setNewCommentContent("");
+    setActiveCommentMenuId("");
+    setEditingCommentId("");
+    setEditCommentContent("");
+    setDeleteTargetCommentId("");
+    setModalCommentsError("");
+    setIsLoadingModalComments(false);
+  };
+
+  const openCommentModal = async (confessionId, authorName) => {
+    setActiveCommentConfessionId(confessionId);
+    setCommentModalTitle(authorName || "Confession");
+    setModalComments([]);
+    setNewCommentContent("");
+    setActiveCommentMenuId("");
+    setEditingCommentId("");
+    setEditCommentContent("");
+    setDeleteTargetCommentId("");
+    await loadModalComments(confessionId);
+  };
+
+  const handleAddComment = async () => {
+    if (!activeCommentConfessionId) {
+      return;
+    }
+
+    const cleanedContent = newCommentContent.trim();
+    const token = localStorage.getItem("token");
+    const hasContent = cleanedContent.length > 0;
+
+    if (!hasContent || !token) {
+      setModalCommentsError(
+        hasContent
+          ? "Please log in to comment."
+          : "Write something before posting your comment.",
+      );
+      return;
+    }
+
+    setIsSubmittingComment(true);
+    setModalCommentsError("");
+
+    try {
+      const response = await fetch(
+        `/api/confessions/${activeCommentConfessionId}/comments`,
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({ content: cleanedContent }),
+        },
+      );
+      const payload = await parseResponse(response);
+
+      if (!response.ok) {
+        throw new Error(payload?.message || "Failed to add comment.");
+      }
+
+      setNewCommentContent("");
+      await loadModalComments(activeCommentConfessionId);
+      updateConfessionCommentCount(activeCommentConfessionId, 1);
+    } catch (error) {
+      setModalCommentsError(error.message || "Failed to add comment.");
+    } finally {
+      setIsSubmittingComment(false);
+    }
+  };
+
+  const handleToggleCommentMenu = (commentId) => {
+    setActiveCommentMenuId((currentId) =>
+      currentId === commentId ? "" : commentId,
+    );
+  };
+
+  const handleStartEditComment = (comment) => {
+    const commentId = String(comment?._id || comment?.id || "");
+    setActiveCommentMenuId("");
+    setDeleteTargetCommentId("");
+    setEditingCommentId(commentId);
+    setEditCommentContent(comment?.content || "");
+  };
+
+  const handleCancelEditComment = () => {
+    setEditingCommentId("");
+    setEditCommentContent("");
+  };
+
+  const handleSaveEditedComment = async (commentId) => {
+    const cleanedContent = editCommentContent.trim();
+    const token = localStorage.getItem("token");
+    const hasContent = cleanedContent.length > 0;
+
+    if (!hasContent || !token) {
+      setModalCommentsError(
+        hasContent
+          ? "Please log in to edit your comment."
+          : "Comment cannot be empty.",
+      );
+      return;
+    }
+
+    setIsSavingEditedComment(true);
+    setModalCommentsError("");
+
+    try {
+      const response = await fetch(`/api/confessions/comments/${commentId}`, {
+        method: "PUT",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${token}`,
+        },
+        body: JSON.stringify({ content: cleanedContent }),
+      });
+      const payload = await parseResponse(response);
+
+      if (!response.ok) {
+        throw new Error(payload?.message || "Failed to edit comment.");
+      }
+
+      setModalComments((prev) =>
+        prev.map((comment) => {
+          const currentId = String(comment?._id || comment?.id || "");
+
+          if (currentId !== commentId) {
+            return comment;
+          }
+
+          return {
+            ...comment,
+            content: cleanedContent,
+            isEdited: true,
+            updatedAt: new Date().toISOString(),
+          };
+        }),
+      );
+
+      setEditingCommentId("");
+      setEditCommentContent("");
+    } catch (error) {
+      setModalCommentsError(error.message || "Failed to edit comment.");
+    } finally {
+      setIsSavingEditedComment(false);
+    }
+  };
+
+  const handleDeleteComment = (commentId) => {
+    setActiveCommentMenuId("");
+    setEditingCommentId("");
+    setEditCommentContent("");
+    setDeleteTargetCommentId(commentId);
+  };
+
+  const handleConfirmDeleteComment = async () => {
+    if (!deleteTargetCommentId || !activeCommentConfessionId) {
+      return;
+    }
+
+    const token = localStorage.getItem("token");
+
+    if (!token) {
+      setModalCommentsError("Please log in to delete your comment.");
+      return;
+    }
+
+    setIsDeletingComment(true);
+    setModalCommentsError("");
+
+    try {
+      const response = await fetch(
+        `/api/confessions/comments/${deleteTargetCommentId}`,
+        {
+          method: "DELETE",
+          headers: {
+            Authorization: `Bearer ${token}`,
+          },
+        },
+      );
+      const payload = await parseResponse(response);
+
+      if (!response.ok) {
+        throw new Error(payload?.message || "Failed to delete comment.");
+      }
+
+      const deletedId = deleteTargetCommentId;
+      setDeleteTargetCommentId("");
+      setModalComments((prev) =>
+        prev.filter(
+          (comment) => String(comment?._id || comment?.id || "") !== deletedId,
+        ),
+      );
+      updateConfessionCommentCount(activeCommentConfessionId, -1);
+    } catch (error) {
+      setModalCommentsError(error.message || "Failed to delete comment.");
+    } finally {
+      setIsDeletingComment(false);
+    }
+  };
+
+  useOutsideClickCloser(
+    Boolean(activeCommentMenuId),
+    () => setActiveCommentMenuId(""),
+    "[data-comment-menu]",
+  );
+
+  return {
+    activeCommentConfessionId,
+    commentModalTitle,
+    modalComments,
+    newCommentContent,
+    setNewCommentContent,
+    isSubmittingComment,
+    activeCommentMenuId,
+    editingCommentId,
+    editCommentContent,
+    setEditCommentContent,
+    isSavingEditedComment,
+    deleteTargetCommentId,
+    setDeleteTargetCommentId,
+    isDeletingComment,
+    isLoadingModalComments,
+    modalCommentsError,
+    closeCommentModal,
+    openCommentModal,
+    handleAddComment,
+    handleToggleCommentMenu,
+    handleStartEditComment,
+    handleCancelEditComment,
+    handleSaveEditedComment,
+    handleDeleteComment,
+    handleConfirmDeleteComment,
+  };
+};

--- a/frontend/src/pages/confession/useConfessionComments.js
+++ b/frontend/src/pages/confession/useConfessionComments.js
@@ -24,6 +24,32 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
     React.useState("");
   const [modalCommentsHasMore, setModalCommentsHasMore] = React.useState(false);
 
+  const getCommentId = React.useCallback(
+    (comment) => String(comment?._id || comment?.id || ""),
+    [],
+  );
+
+  const mergeCommentsById = React.useCallback(
+    (incomingComments, existingComments = []) => {
+      const seenIds = new Set();
+      const mergedComments = [];
+
+      [...incomingComments, ...existingComments].forEach((comment) => {
+        const commentId = getCommentId(comment);
+
+        if (!commentId || seenIds.has(commentId)) {
+          return;
+        }
+
+        seenIds.add(commentId);
+        mergedComments.push(comment);
+      });
+
+      return mergedComments;
+    },
+    [getCommentId],
+  );
+
   const updateConfessionCommentCount = React.useCallback(
     (confessionId, by) => {
       setConfessionFeed((prev) =>
@@ -45,7 +71,7 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
   );
 
   const loadModalComments = React.useCallback(
-    async (confessionId, cursor = "") => {
+    async (confessionId, cursor = "", { preservePagination = false } = {}) => {
       setModalCommentsError("");
       setIsLoadingModalComments(true);
 
@@ -74,16 +100,23 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
         const nextCursor = payload?.nextCursor || "";
         const hasMore = Boolean(payload?.hasMore);
 
-        setModalComments((prev) => [...prev, ...comments]);
-        setModalCommentsNextCursor(nextCursor);
-        setModalCommentsHasMore(hasMore);
+        setModalComments((prev) =>
+          preservePagination
+            ? mergeCommentsById(comments, prev)
+            : mergeCommentsById(prev, comments),
+        );
+
+        if (!preservePagination) {
+          setModalCommentsNextCursor(nextCursor);
+          setModalCommentsHasMore(hasMore);
+        }
       } catch (error) {
         setModalCommentsError(error.message || "Failed to load comments.");
       } finally {
         setIsLoadingModalComments(false);
       }
     },
-    [],
+    [mergeCommentsById],
   );
 
   const loadMoreModalComments = React.useCallback(async () => {
@@ -174,10 +207,9 @@ export const useConfessionComments = ({ setConfessionFeed }) => {
       }
 
       setNewCommentContent("");
-      setModalComments([]);
-      setModalCommentsNextCursor("");
-      setModalCommentsHasMore(false);
-      await loadModalComments(activeCommentConfessionId);
+      await loadModalComments(activeCommentConfessionId, "", {
+        preservePagination: true,
+      });
       updateConfessionCommentCount(activeCommentConfessionId, 1);
     } catch (error) {
       setModalCommentsError(error.message || "Failed to add comment.");

--- a/frontend/src/pages/confession/useOutsideClickCloser.js
+++ b/frontend/src/pages/confession/useOutsideClickCloser.js
@@ -1,0 +1,28 @@
+import React from "react";
+
+export const useOutsideClickCloser = (isActive, onClose, containerSelector) => {
+  React.useEffect(() => {
+    if (!isActive) {
+      return undefined;
+    }
+
+    const handleClickOutside = (event) => {
+      if (
+        event.target instanceof Element &&
+        event.target.closest(containerSelector)
+      ) {
+        return;
+      }
+
+      onClose();
+    };
+
+    document.addEventListener("mousedown", handleClickOutside);
+    document.addEventListener("touchstart", handleClickOutside);
+
+    return () => {
+      document.removeEventListener("mousedown", handleClickOutside);
+      document.removeEventListener("touchstart", handleClickOutside);
+    };
+  }, [isActive, onClose, containerSelector]);
+};


### PR DESCRIPTION
Introduces several improvements to the backend confession and comment models, primarily to support displaying user profile pictures alongside display names and to better track the editing status of confessions. It also updates the frontend dependencies. The most important changes are grouped below.

**Backend: Confession and Comment Model Enhancements**

* Added support for returning the author's `profilePicture` in all confession, comment, and reply queries by updating the `$project` stage and response objects in `confessionModel.js` and `confessionCommentModel.js`. This makes it possible for the frontend to display user profile pictures where appropriate.
* Implemented the `resolveAuthorProfilePicture` function in `confessionModel.js` to ensure profile pictures are only shown if the confession is not anonymous or if the current user is the author.
* Added the `isEdited` field to confessions, setting it to `false` on creation and updating it to `true` on edit to track whether a confession has been modified after posting. Also added `isEdited` to the protected fields list.

**Frontend: Dependency Updates**

* Added `prop-types` as a dependency in the frontend `package-lock.json`.
* Marked several packages as dev dependencies in `package-lock.json` for improved dependency management.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Full confession feed: create/edit/delete, anonymous vs identified, public/private, infinite scroll, hashtag extraction, per-card expand/collapse
  * Comments modal: paginated load, add/edit/delete, richer comment UI with author avatars and threaded replies
  * Improved interactions: gesture liking, save/bookmark toggle, share fallbacks, dismissible toasts, accessible modals

* **Bug Fixes / Improvements**
  * Edited items show “Edited” and persist state
  * Deletions return accurate removed counts and update counts/toasts accordingly
<!-- end of auto-generated comment: release notes by coderabbit.ai -->