### PR TITLE
tags issue #90

### DIFF
--- a/frontend/src/pages/Bookmarks.jsx
+++ b/frontend/src/pages/Bookmarks.jsx
@@ -114,6 +114,7 @@ const PostCard = ({
   author,
   authorId,
   avatar,
+  genres,
   genre,
   tags,
   time,
@@ -128,6 +129,17 @@ const PostCard = ({
   onOpenComments,
   onToggleExpanded,
 }) => {
+  const [areGenresExpanded, setAreGenresExpanded] = useState(false);
+  const genreDisplayLimit = 5;
+  const storyGenres =
+    Array.isArray(genres) && genres.length > 0
+      ? genres
+      : [String(genre || "GENERAL")];
+  const visibleGenres = areGenresExpanded
+    ? storyGenres
+    : storyGenres.slice(0, genreDisplayLimit);
+  const hiddenGenreCount = Math.max(storyGenres.length - genreDisplayLimit, 0);
+
   const { visibleContent, isLongContent } = getContentPreview(
     content,
     isExpanded,
@@ -164,9 +176,48 @@ const PostCard = ({
               <span className="text-slate-400 text-xs">• {time}</span>
             </div>
 
-            <span className="text-[10px] font-semibold text-rose-500 uppercase tracking-wider">
-              {genre}
-            </span>
+            <div className="mt-1 flex flex-wrap items-center gap-x-2 gap-y-1">
+              {visibleGenres.map((storyGenre, index) => (
+                <span
+                  key={`${id}-genre-${String(storyGenre)}-${index}`}
+                  className="inline-flex items-center gap-2"
+                >
+                  {index > 0 && (
+                    <span
+                      aria-hidden="true"
+                      className="text-[10px] font-semibold text-rose-400"
+                    >
+                      •
+                    </span>
+                  )}
+                  <span className="text-[10px] font-semibold uppercase tracking-wider text-rose-500">
+                    {storyGenre}
+                  </span>
+                </span>
+              ))}
+
+              {hiddenGenreCount > 0 && !areGenresExpanded && (
+                <button
+                  type="button"
+                  onClick={() => setAreGenresExpanded(true)}
+                  className="text-[10px] font-semibold uppercase cursor-pointer tracking-wider text-rose-600 transition-colors hover:text-rose-700"
+                  aria-label={`Show ${hiddenGenreCount} more genres`}
+                >
+                  +{hiddenGenreCount}
+                </button>
+              )}
+
+              {hiddenGenreCount > 0 && areGenresExpanded && (
+                <button
+                  type="button"
+                  onClick={() => setAreGenresExpanded(false)}
+                  className="text-[10px] font-semibold uppercase cursor-pointer tracking-wider text-slate-500 transition-colors hover:text-slate-700"
+                  aria-label="Collapse genres"
+                >
+                  Show less
+                </button>
+              )}
+            </div>
           </div>
         </div>
       </div>
@@ -521,6 +572,10 @@ export default function Bookmarks() {
             story.authorDisplayName ||
             "Anonymous Author",
           avatar: profile?.profilePicture || null,
+          genres:
+            Array.isArray(story.genres) && story.genres.length > 0
+              ? story.genres.map((item) => String(item).toUpperCase())
+              : ["GENERAL"],
           genre: story.genres?.[0]?.toUpperCase() || "GENERAL",
           tags: Array.isArray(story.tags) ? story.tags : [],
           time: getRelativeTime(story.publishedAt || story.createdAt),

--- a/frontend/src/pages/Explore.jsx
+++ b/frontend/src/pages/Explore.jsx
@@ -113,6 +113,64 @@ const AuthorRow = ({
   </div>
 );
 
+const ExpandableGenreChips = ({ storyId, genres, limit = 5 }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const safeGenres = Array.isArray(genres) && genres.length > 0 ? genres : [];
+  const visibleGenres = isExpanded ? safeGenres : safeGenres.slice(0, limit);
+  const hiddenGenresCount = Math.max(safeGenres.length - limit, 0);
+
+  return (
+    <div className="flex flex-wrap items-center gap-x-2 gap-y-1">
+      {visibleGenres.map((genre, index) => (
+        <span
+          key={`${storyId}-genre-${String(genre)}-${index}`}
+          className="inline-flex items-center gap-2"
+        >
+          {index > 0 && (
+            <span
+              aria-hidden="true"
+              className="text-[10px] font-semibold text-rose-400"
+            >
+              •
+            </span>
+          )}
+          <span className="text-[10px] font-semibold uppercase tracking-wider text-rose-500">
+            {String(genre)}
+          </span>
+        </span>
+      ))}
+
+      {hiddenGenresCount > 0 && !isExpanded && (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            setIsExpanded(true);
+          }}
+          className="text-[10px] font-semibold uppercase cursor-pointer tracking-wider text-rose-600 transition-colors hover:text-rose-700"
+          aria-label={`Show ${hiddenGenresCount} more genres`}
+        >
+          +{hiddenGenresCount}
+        </button>
+      )}
+
+      {hiddenGenresCount > 0 && isExpanded && (
+        <button
+          type="button"
+          onClick={(event) => {
+            event.stopPropagation();
+            setIsExpanded(false);
+          }}
+          className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 transition-colors hover:text-slate-700"
+          aria-label="Collapse genres"
+        >
+          Show less
+        </button>
+      )}
+    </div>
+  );
+};
+
 export default function Explore() {
   const navigate = useNavigate();
   const [menuStoryId, setMenuStoryId] = useState(null);
@@ -687,16 +745,13 @@ export default function Explore() {
                       }
                       className="cursor-pointer bg-white rounded-2xl sm:rounded-3xl p-4 sm:p-6 border border-slate-200 shadow-sm transition-all duration-300 hover:shadow-md h-full flex flex-col"
                     >
-                      <div className="flex flex-wrap justify-between items-start gap-3 mb-4">
-                        <div className="flex flex-wrap gap-2">
-                          {story.tags.map((tag, idx) => (
-                            <span
-                              key={idx}
-                              className="bg-rose-50 text-rose-500 text-[10px] font-semibold px-3 py-1 rounded-md uppercase"
-                            >
-                              {String(tag)}
-                            </span>
-                          ))}
+                      <div className="flex items-start justify-between gap-3 mb-4">
+                        <div className="min-w-0 flex-1">
+                          <ExpandableGenreChips
+                            storyId={story.id}
+                            genres={story.tags}
+                            limit={5}
+                          />
                         </div>
 
                         <div className="flex items-center gap-2 text-slate-500 shrink-0">
@@ -899,16 +954,13 @@ export default function Explore() {
                       }
                       className="cursor-pointer bg-white rounded-2xl sm:rounded-3xl p-4 sm:p-6 border border-slate-200 shadow-sm transition-all duration-300 hover:shadow-md h-full flex flex-col"
                     >
-                      <div className="flex flex-wrap justify-between items-start gap-3 mb-4">
-                        <div className="flex flex-wrap gap-2">
-                          {story.tags.map((tag, idx) => (
-                            <span
-                              key={idx}
-                              className="bg-rose-50 text-rose-500 text-[10px] font-semibold px-3 py-1 rounded-md uppercase"
-                            >
-                              {String(tag)}
-                            </span>
-                          ))}
+                      <div className="flex items-start justify-between gap-3 mb-4">
+                        <div className="min-w-0 flex-1">
+                          <ExpandableGenreChips
+                            storyId={story.id}
+                            genres={story.tags}
+                            limit={5}
+                          />
                         </div>
 
                         <div className="flex items-center gap-2 text-slate-500 shrink-0">

--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -176,9 +176,17 @@ const PostCard = ({
   focused,
 }) => {
   const [isContentMeasured, setIsContentMeasured] = useState(false);
+  const [areGenresExpanded, setAreGenresExpanded] = useState(false);
   const contentRef = useRef(null);
   const collapsedContentHeight = 120;
+  const genreDisplayLimit = 5;
   const storyContent = content || excerpt || "";
+  const storyGenres =
+    Array.isArray(genres) && genres.length > 0 ? genres : ["GENERAL"];
+  const visibleGenres = areGenresExpanded
+    ? storyGenres
+    : storyGenres.slice(0, genreDisplayLimit);
+  const hiddenGenreCount = Math.max(storyGenres.length - genreDisplayLimit, 0);
 
   useEffect(() => {
     const element = contentRef.current;
@@ -223,11 +231,11 @@ const PostCard = ({
         </div>
       )}
 
-      <div className="flex justify-between items-start mb-4">
-        <div className="flex items-center gap-3 min-w-0">
+      <div className="flex justify-between items-start gap-3 mb-4">
+        <div className="flex items-start gap-3 min-w-0 flex-1">
           <Link
             to={authorId ? `/profile/${authorId}` : "/profile"}
-            className="w-10 h-10 rounded-full bg-slate-200 overflow-hidden block transition-all duration-150 hover:ring-2 hover:ring-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
+            className="w-10 h-10 shrink-0 rounded-full bg-slate-200 overflow-hidden block transition-all duration-150 hover:ring-2 hover:ring-slate-200 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-slate-300"
             aria-label={`View ${author} profile`}
           >
             {avatar ? (
@@ -254,12 +262,48 @@ const PostCard = ({
               <span className="text-slate-400 text-xs">• {time}</span>
             </div>
 
-            <span className="text-[10px] font-semibold text-rose-500 uppercase tracking-wider">
-              {(Array.isArray(genres) && genres.length > 0
-                ? genres
-                : ["GENERAL"]
-              ).join(" • ")}
-            </span>
+            <div className="mt-1 flex max-w-full flex-wrap items-center gap-x-2 gap-y-1">
+              {visibleGenres.map((genre, index) => (
+                <span
+                  key={`${id}-genre-${String(genre)}-${index}`}
+                  className="inline-flex max-w-full items-center gap-2"
+                >
+                  {index > 0 && (
+                    <span
+                      aria-hidden="true"
+                      className="text-[10px] font-semibold text-rose-400"
+                    >
+                      •
+                    </span>
+                  )}
+                  <span className="max-w-full truncate text-[10px] font-semibold uppercase tracking-wider text-rose-500">
+                    {genre}
+                  </span>
+                </span>
+              ))}
+
+              {hiddenGenreCount > 0 && !areGenresExpanded && (
+                <button
+                  type="button"
+                  onClick={() => setAreGenresExpanded(true)}
+                  className="text-[10px] font-semibold uppercase cursor-pointer tracking-wider text-rose-600 transition-colors hover:text-rose-700"
+                  aria-label={`Show ${hiddenGenreCount} more genres`}
+                >
+                  +{hiddenGenreCount}
+                </button>
+              )}
+
+              {hiddenGenreCount > 0 && areGenresExpanded && (
+                <button
+                  type="button"
+                  onClick={() => setAreGenresExpanded(false)}
+                  className="text-[10px] font-semibold uppercase cursor-pointer tracking-wider text-slate-500 transition-colors hover:text-slate-700"
+                  aria-label="Collapse genres"
+                >
+                  Show less
+                </button>
+              )}
+            </div>
           </div>
         </div>
 

--- a/frontend/src/pages/Profile.jsx
+++ b/frontend/src/pages/Profile.jsx
@@ -88,53 +88,104 @@ const mapStoryToCard = (story, overrides = {}) => ({
   ...overrides,
 });
 
-const StoryCard = ({ story, actionLabel, actionHref, onClick }) => (
-  <div
-    role="button"
-    tabIndex={0}
-    onKeyDown={(e) => {
-      if (e.key === "Enter" && typeof onClick === "function") onClick();
-    }}
-    onClick={onClick}
-    className="bg-white rounded-2xl border border-slate-200 p-4 sm:p-6 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
-  >
-    <div className="mb-2 flex items-center justify-between gap-3">
-      <h3 className="text-xl font-semibold text-slate-900">{story.title}</h3>
-      <div className="flex flex-wrap gap-1">
-        {Array.isArray(story.genres)
-          ? story.genres.map((genre, idx) => (
-              <span
-                key={genre + idx}
-                className="text-[10px] font-semibold text-rose-500 uppercase tracking-wider bg-rose-50 px-2 py-0.5 rounded"
-              >
+const StoryCard = ({ story, actionLabel, actionHref, onClick }) => {
+  const [areGenresExpanded, setAreGenresExpanded] = useState(false);
+  const genreDisplayLimit = 5;
+  const storyGenres =
+    Array.isArray(story.genres) && story.genres.length > 0
+      ? story.genres
+      : story.genre
+        ? [String(story.genre).toUpperCase()]
+        : ["GENERAL"];
+  const visibleGenres = areGenresExpanded
+    ? storyGenres
+    : storyGenres.slice(0, genreDisplayLimit);
+  const hiddenGenreCount = Math.max(storyGenres.length - genreDisplayLimit, 0);
+
+  return (
+    <div
+      role="button"
+      tabIndex={0}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" && typeof onClick === "function") onClick();
+      }}
+      onClick={onClick}
+      className="bg-white rounded-2xl border border-slate-200 p-4 sm:p-6 shadow-sm hover:shadow-md transition-shadow cursor-pointer"
+    >
+      <div className="mb-2 flex items-start justify-between gap-3">
+        <h3 className="text-xl font-semibold text-slate-900">{story.title}</h3>
+        <div className="flex flex-wrap items-center justify-end gap-x-2 gap-y-1">
+          {visibleGenres.map((genre, idx) => (
+            <span
+              key={`${story.id}-genre-${genre}-${idx}`}
+              className="inline-flex items-center gap-2"
+            >
+              {idx > 0 && (
+                <span
+                  aria-hidden="true"
+                  className="text-[10px] font-semibold text-rose-400"
+                >
+                  •
+                </span>
+              )}
+              <span className="text-[10px] font-semibold text-rose-500 uppercase tracking-wider">
                 {genre}
               </span>
-            ))
-          : null}
+            </span>
+          ))}
+
+          {hiddenGenreCount > 0 && !areGenresExpanded && (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                setAreGenresExpanded(true);
+              }}
+              className="text-[10px] font-semibold uppercase tracking-wider text-rose-600 transition-colors hover:text-rose-700"
+              aria-label={`Show ${hiddenGenreCount} more genres`}
+            >
+              +{hiddenGenreCount}
+            </button>
+          )}
+
+          {hiddenGenreCount > 0 && areGenresExpanded && (
+            <button
+              type="button"
+              onClick={(event) => {
+                event.stopPropagation();
+                setAreGenresExpanded(false);
+              }}
+              className="text-[10px] font-semibold uppercase tracking-wider text-slate-500 transition-colors hover:text-slate-700"
+              aria-label="Collapse genres"
+            >
+              Show less
+            </button>
+          )}
+        </div>
       </div>
+      <p className="text-sm text-slate-500 italic mb-6">{story.excerpt}</p>
+      <div className="flex flex-wrap items-center justify-end gap-4 sm:gap-6 text-[10px] font-semibold text-slate-500 uppercase tracking-tighter">
+        <div className="flex items-center gap-1">
+          <span>{story.likes} likes</span>
+        </div>
+        <div className="flex items-center gap-1">
+          <span>{story.savesLabel || `${story.saves} Saves`}</span>
+        </div>
+        <div>{story.date}</div>
+      </div>
+      {actionHref && actionLabel ? (
+        <div className="mt-5 flex justify-end">
+          <Link
+            to={actionHref}
+            className="text-xs font-semibold text-rose-500 hover:text-rose-600"
+          >
+            {actionLabel}
+          </Link>
+        </div>
+      ) : null}
     </div>
-    <p className="text-sm text-slate-500 italic mb-6">{story.excerpt}</p>
-    <div className="flex flex-wrap items-center justify-end gap-4 sm:gap-6 text-[10px] font-semibold text-slate-500 uppercase tracking-tighter">
-      <div className="flex items-center gap-1">
-        <span>{story.likes} likes</span>
-      </div>
-      <div className="flex items-center gap-1">
-        <span>{story.savesLabel || `${story.saves} Saves`}</span>
-      </div>
-      <div>{story.date}</div>
-    </div>
-    {actionHref && actionLabel ? (
-      <div className="mt-5 flex justify-end">
-        <Link
-          to={actionHref}
-          className="text-xs font-semibold text-rose-500 hover:text-rose-600"
-        >
-          {actionLabel}
-        </Link>
-      </div>
-    ) : null}
-  </div>
-);
+  );
+};
 
 export default function Profile() {
   const navigate = useNavigate();

--- a/frontend/src/pages/Write.jsx
+++ b/frontend/src/pages/Write.jsx
@@ -53,6 +53,27 @@ const normalizeGenres = (inputGenres) => {
   }, []);
 };
 
+const extractTagsFromInput = (rawInput) => {
+  const matches = String(rawInput || "").match(/#\w+/g) || [];
+  const uniqueByLowercase = new Map();
+
+  for (const rawTag of matches) {
+    const cleanedTag = rawTag.slice(1).trim();
+
+    if (!cleanedTag) {
+      continue;
+    }
+
+    const normalizedKey = cleanedTag.toLowerCase();
+
+    if (!uniqueByLowercase.has(normalizedKey)) {
+      uniqueByLowercase.set(normalizedKey, cleanedTag);
+    }
+  }
+
+  return Array.from(uniqueByLowercase.values());
+};
+
 export default function Write() {
   const [searchParams] = useSearchParams();
   const [title, setTitle] = useState("");
@@ -103,7 +124,11 @@ export default function Write() {
               : [],
           ),
         );
-        setTags(Array.isArray(payload?.tags) ? payload.tags.join(", ") : "");
+        setTags(
+          Array.isArray(payload?.tags)
+            ? payload.tags.map((tag) => `#${tag}`).join(" ")
+            : "",
+        );
         setVisibility(payload?.visibility || "public");
       } catch (error) {
         if (isMounted) {
@@ -153,18 +178,7 @@ export default function Write() {
   };
 
   const parseTagsArray = () => {
-    return tags
-      .split(",")
-      .map((raw) => raw.trim())
-      .filter((raw) => raw.length > 0)
-      .map((raw) => {
-        // remove leading # if present
-        const withoutHash = raw.startsWith("#") ? raw.slice(1) : raw;
-        // only take the first word (stop at whitespace)
-        const firstWord = withoutHash.split(/\s+/)[0] || "";
-        return firstWord.trim();
-      })
-      .filter((t) => t.length > 0);
+    return extractTagsFromInput(tags);
   };
 
   const getGenresForSubmit = () => {
@@ -279,7 +293,7 @@ export default function Write() {
 
         <main className="flex-1 min-h-0 overflow-hidden">
           <div className="h-full overflow-y-auto [scrollbar-width:none] [-ms-overflow-style:none] [&::-webkit-scrollbar]:hidden">
-            <div className="flex flex-col lg:flex-row max-w-[1400px] mx-auto w-full p-3 sm:p-5 lg:p-8 gap-6 lg:gap-12">
+            <div className="flex flex-col lg:flex-row max-w-350 mx-auto w-full p-3 sm:p-5 lg:p-8 gap-6 lg:gap-12">
               {/* Editor Section */}
               <div className="flex-1 bg-white p-4 sm:p-8 lg:p-12 shadow-sm border border-slate-200 rounded-2xl">
                 <div className="max-w-3xl mx-auto">
@@ -295,10 +309,10 @@ export default function Write() {
                     value={title}
                     onChange={(e) => setTitle(e.target.value)}
                   />
-                  <div className="h-[1px] bg-slate-200 w-full mb-10"></div>
+                  <div className="h-px bg-slate-200 w-full mb-10"></div>
                   <textarea
                     placeholder="Untitled story line..."
-                    className="w-full min-h-[360px] sm:min-h-[500px] lg:min-h-[600px] text-base sm:text-lg lg:text-xl text-slate-300 focus:text-slate-700 outline-none resize-none leading-relaxed"
+                    className="w-full min-h-90 sm:min-h-125 lg:min-h-150 text-base sm:text-lg lg:text-xl text-slate-300 focus:text-slate-700 outline-none resize-none leading-relaxed"
                     value={content}
                     onChange={(e) => setContent(e.target.value)}
                   />
@@ -306,7 +320,7 @@ export default function Write() {
               </div>
 
               {/* Story Metadata Panel */}
-              <aside className="w-full lg:w-[340px] flex flex-col gap-8 lg:gap-10 lg:sticky lg:top-24 self-start">
+              <aside className="w-full lg:w-85 flex flex-col gap-8 lg:gap-10 lg:sticky lg:top-24 self-start">
                 {/* Story Details */}
                 <section>
                   <h3 className="text-[11px] font-semibold text-slate-500 uppercase tracking-widest mb-6">
@@ -356,7 +370,7 @@ export default function Write() {
                     Tags #
                   </h3>
                   <textarea
-                    placeholder="Eg. #DailyLifeMotivation, #NeedAdvice, ..."
+                    placeholder="Eg. #DailyLifeMotivation #NeedAdvice"
                     className="w-full h-32 p-4 border border-slate-300 rounded-2xl text-sm bg-slate-50 outline-none focus:bg-white focus:border-rose-300 transition-all resize-none italic text-slate-400"
                     value={tags}
                     onChange={(e) => setTags(e.target.value)}


### PR DESCRIPTION
Introduces a consistent, expandable display for genres/tags across the Home, Bookmarks, Profile, and Explore pages and improves tag parsing in the Write page. The main goal is to enhance the user experience when viewing or editing stories with multiple genres or tags, ensuring long lists are truncated and can be expanded or collapsed as needed. Additionally, tag input and parsing in the Write page is improved for reliability and user-friendliness.

**UI improvements for genres/tags display:**

* Genres/tags are now displayed as a list of chips with a maximum of 5 visible by default, with a "+N" button to expand and "Show less" to collapse, across `Home`, `Bookmarks`, `Profile`, and `Explore` pages. This prevents overflow and keeps the UI clean for stories with many genres/tags. 
* A reusable `ExpandableGenreChips` component is added to `Explore.jsx` for consistent handling of expandable genre/tag chips.

**Data handling and normalization:**

* The logic for passing, normalizing, and displaying genres is unified across pages, ensuring that genres are uppercased and default to "GENERAL" when missing. 

**Write page improvements:**

* Tag input now expects tags in the format `#tag1 #tag2` (space-separated, with `#`), and parsing is handled by a new `extractTagsFromInput` utility for more robust extraction and deduplication.
* When loading an existing story, tags are displayed in the new `#tag1 #tag2` format.
* Minor UI tweaks for consistency and improved layout, including fixed widths and improved placeholder text.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added expandable genre display across story cards; genres initially show up to 5 items with "show more" functionality to reveal additional genres.
  * Enhanced tags input to support hashtag format in the Write section for improved tag management.

* **Style**
  * Improved layout and spacing for genre chips and story card components across bookmarks, explore, home, and profile pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->