### PR TITLE
tags display issue #92

### DIFF
--- a/frontend/src/pages/Home.jsx
+++ b/frontend/src/pages/Home.jsx
@@ -177,16 +177,30 @@ const PostCard = ({
 }) => {
   const [isContentMeasured, setIsContentMeasured] = useState(false);
   const [areGenresExpanded, setAreGenresExpanded] = useState(false);
+  const [areTagsExpanded, setAreTagsExpanded] = useState(false);
+  const [areTagsWrapped, setAreTagsWrapped] = useState(false);
+  const [firstRowTagCount, setFirstRowTagCount] = useState(4);
   const contentRef = useRef(null);
+  const tagMeasurementRef = useRef(null);
   const collapsedContentHeight = 120;
   const genreDisplayLimit = 5;
   const storyContent = content || excerpt || "";
   const storyGenres =
     Array.isArray(genres) && genres.length > 0 ? genres : ["GENERAL"];
+  const storyTags = Array.isArray(tags) ? tags : [];
   const visibleGenres = areGenresExpanded
     ? storyGenres
     : storyGenres.slice(0, genreDisplayLimit);
   const hiddenGenreCount = Math.max(storyGenres.length - genreDisplayLimit, 0);
+  const hiddenTagCount = areTagsWrapped
+    ? Math.max(storyTags.length - firstRowTagCount, 0)
+    : 0;
+  const canExpandTags = hiddenTagCount > 0;
+  const isTagsExpanded = canExpandTags && areTagsExpanded;
+  const visibleTags =
+    areTagsWrapped && !isTagsExpanded
+      ? storyTags.slice(0, firstRowTagCount)
+      : storyTags;
 
   useEffect(() => {
     const element = contentRef.current;
@@ -213,6 +227,54 @@ const PostCard = ({
 
     return () => observer.disconnect();
   }, [collapsedContentHeight, storyContent]);
+
+  useEffect(() => {
+    const measurementElement = tagMeasurementRef.current;
+
+    if (!measurementElement) {
+      return undefined;
+    }
+
+    const updateTagWrapState = () => {
+      const tagElements = Array.from(
+        measurementElement.querySelectorAll('[data-tag-chip="true"]'),
+      );
+
+      if (tagElements.length === 0) {
+        setAreTagsWrapped(false);
+        setFirstRowTagCount(4);
+        return;
+      }
+
+      const firstRowTop = tagElements[0].offsetTop;
+      const calculatedFirstRowCount = tagElements.filter(
+        (tagElement) => tagElement.offsetTop <= firstRowTop + 1,
+      ).length;
+      const safeFirstRowCount = Math.max(calculatedFirstRowCount, 1);
+
+      setFirstRowTagCount(safeFirstRowCount);
+      setAreTagsWrapped(safeFirstRowCount < tagElements.length);
+    };
+
+    const frameId = requestAnimationFrame(() => {
+      updateTagWrapState();
+    });
+
+    if (typeof ResizeObserver === "undefined") {
+      return () => cancelAnimationFrame(frameId);
+    }
+
+    const observer = new ResizeObserver(() => {
+      updateTagWrapState();
+    });
+
+    observer.observe(measurementElement);
+
+    return () => {
+      cancelAnimationFrame(frameId);
+      observer.disconnect();
+    };
+  }, [storyTags]);
 
   return (
     <div
@@ -406,20 +468,64 @@ const PostCard = ({
 
       {!isContentMeasured && <div className="mb-4" />}
 
-      {Array.isArray(tags) && tags.length > 0 && (
-        <div className="mb-4 flex flex-wrap items-center gap-x-3 gap-y-1">
-          {tags.slice(0, 4).map((tag) => (
-            <span
-              key={`${id}-${tag}`}
-              className="text-xs font-semibold tracking-wide text-rose-600"
-            >
-              #
-              {String(tag || "")
-                .trim()
-                .replace(/^#/, "")
-                .replaceAll(/\s+/g, "")}
-            </span>
-          ))}
+      {storyTags.length > 0 && (
+        <div className="relative mb-4">
+          <div
+            ref={tagMeasurementRef}
+            aria-hidden="true"
+            className="pointer-events-none absolute left-0 top-0 -z-10 flex w-full flex-wrap items-center gap-x-3 gap-y-1 opacity-0"
+          >
+            {storyTags.map((tag, index) => (
+              <span
+                key={`${id}-measure-tag-${String(tag)}-${index}`}
+                data-tag-chip="true"
+                className="text-xs font-semibold tracking-wide text-rose-600"
+              >
+                #
+                {String(tag || "")
+                  .trim()
+                  .replace(/^#/, "")
+                  .replaceAll(/\s+/g, "")}
+              </span>
+            ))}
+          </div>
+
+          <div className="flex flex-wrap items-center gap-x-3 gap-y-1">
+            {visibleTags.map((tag, index) => (
+              <span
+                key={`${id}-tag-${String(tag)}-${index}`}
+                className="text-xs font-semibold tracking-wide text-rose-600"
+              >
+                #
+                {String(tag || "")
+                  .trim()
+                  .replace(/^#/, "")
+                  .replaceAll(/\s+/g, "")}
+              </span>
+            ))}
+
+            {canExpandTags && !isTagsExpanded && (
+              <button
+                type="button"
+                onClick={() => setAreTagsExpanded(true)}
+                className="text-xs font-semibold cursor-pointer tracking-wide text-rose-600 transition-colors hover:text-rose-700"
+                aria-label={`Show ${hiddenTagCount} more tags`}
+              >
+                +{hiddenTagCount}
+              </button>
+            )}
+
+            {canExpandTags && isTagsExpanded && (
+              <button
+                type="button"
+                onClick={() => setAreTagsExpanded(false)}
+                className="text-xs font-semibold cursor-pointer tracking-wide text-slate-500 transition-colors hover:text-slate-700"
+                aria-label="Collapse tags"
+              >
+                Show less
+              </button>
+            )}
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
Enhances the tag display in the `PostCard` component on the `Home.jsx` page by making the tag list more dynamic and user-friendly. The main improvement is the addition of automatic tag wrapping detection, which allows users to expand and collapse the tag list based on available space, providing a cleaner and more interactive UI.

**Tag display improvements:**

* Introduced state variables (`areTagsExpanded`, `areTagsWrapped`, `firstRowTagCount`) and logic to detect when tags wrap onto a new line, enabling dynamic calculation of how many tags fit in the first row and whether the tag list should be expandable.
* Added a `useEffect` with a `ResizeObserver` to automatically update the tag wrapping state when the tag container size changes, ensuring the UI adapts responsively to different screen sizes or content changes.

**UI enhancements:**

* Refactored the tag rendering to use a hidden measurement row for accurate layout calculations and updated the visible tag list to show either a collapsed or expanded set of tags based on user interaction and layout.
* Added "+N" and "Show less" buttons to allow users to expand or collapse the tag list when there are more tags than fit in the first row, improving usability for posts with many tags.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved tag display in post cards with responsive, dynamic layout
  * Tags now intelligently adapt based on available space
  * Added expand/collapse functionality for viewing all tags
  * "+X more" indicator appears when tags are truncated
  * "Show less" button available when expanded

<!-- end of auto-generated comment: release notes by coderabbit.ai -->